### PR TITLE
Feat: 온보딩 2단계 화면 구현

### DIFF
--- a/On-Dot/On-Dot/DesignSystem/OnDotTypo.swift
+++ b/On-Dot/On-Dot/DesignSystem/OnDotTypo.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct OnDotTypo {
     static let pretendardBlack = "Pretendard-Black"
     static let pretendardBold = "Pretendard-Bold"
-    static let pretendardExtraBold = "Pretendart-ExtraBold"
+    static let pretendardExtraBold = "Pretendard-ExtraBold"
     static let pretendardExtraLight = "Pretendard-ExtraLight"
     static let pretendardLight = "Pretendard-Light"
     static let pretendardMedium = "Pretendard-Medium"

--- a/On-Dot/On-Dot/Model/Location/KaKaoAddressData.swift
+++ b/On-Dot/On-Dot/Model/Location/KaKaoAddressData.swift
@@ -1,0 +1,12 @@
+//
+//  KaKaoAddressData.swift
+//  On-Dot
+//
+//  Created by 현수 노트북 on 4/22/25.
+//
+
+struct KaKaoAddressData: Codable {
+    let roadAddress: String
+    let jibunAddress: String
+    let zonecode: String
+}

--- a/On-Dot/On-Dot/View/Navigation/AppRouter.swift
+++ b/On-Dot/On-Dot/View/Navigation/AppRouter.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 final class AppRouter: ObservableObject {
-    @Published var state: AppState = .splash
+    @Published var state: AppState = .onboarding
     @Published var path: [AppState] = []
     
     func navigate(to newState: AppState) {

--- a/On-Dot/On-Dot/View/Onboarding/OnboardingView.swift
+++ b/On-Dot/On-Dot/View/Onboarding/OnboardingView.swift
@@ -75,6 +75,8 @@ struct OnboardingView: View {
         .onChange(of: viewModel.currentStep) { _ in
             switch viewModel.currentStep {
             case 1:
+                isButtonEnabled = !viewModel.hourText.isEmpty || !viewModel.minuteText.isEmpty
+            case 2:
                 isButtonEnabled = !viewModel.address.isEmpty
             default:
                 isButtonEnabled = false

--- a/On-Dot/On-Dot/View/Onboarding/OnboardingView.swift
+++ b/On-Dot/On-Dot/View/Onboarding/OnboardingView.swift
@@ -11,6 +11,7 @@ struct OnboardingView: View {
     @ObservedObject private var viewModel = OnboardingViewModel()
     
     @State private var isButtonEnabled: Bool = false
+    @State private var showAddressWebView: Bool = false
     @FocusState private var focusState: TimeFocusField?
     
     var body: some View {
@@ -24,16 +25,23 @@ struct OnboardingView: View {
                 
                 Spacer().frame(height: 34)
                 
-                switch viewModel.currentStep {
-                case 1:
-                    OnboardingStep1View(
-                        hourText: $viewModel.hourText,
-                        minuteText: $viewModel.minuteText,
-                        focusField: $focusState
-                    )
-                default:
-                    EmptyView()
+                ZStack {
+                    if viewModel.currentStep == 1 {
+                        OnboardingStep1View(
+                            hourText: $viewModel.hourText,
+                            minuteText: $viewModel.minuteText,
+                            focusField: $focusState
+                        )
+                        .transition(.opacity.combined(with: .move(edge: .leading)))
+                    } else if viewModel.currentStep == 2 {
+                        OnboardingStep2View(
+                            address: viewModel.address,
+                            onClickLocationSearchView: { showAddressWebView = true }
+                        )
+                        .transition(.opacity.combined(with: .move(edge: .trailing)))
+                    }
                 }
+                .animation(.easeInOut, value: viewModel.currentStep)
                 
                 Spacer()
                 
@@ -41,7 +49,9 @@ struct OnboardingView: View {
                     content: "다음",
                     action: {
                         if isButtonEnabled {
-                            viewModel.onClickButton()
+                            withAnimation {
+                                viewModel.onClickButton()
+                            }
                         }
                     },
                     style: isButtonEnabled ? .green500 : .gray300
@@ -58,6 +68,20 @@ struct OnboardingView: View {
         }
         .onChange(of: viewModel.minuteText) { _ in
             isButtonEnabled = !viewModel.hourText.isEmpty || !viewModel.minuteText.isEmpty
+        }
+        .onChange(of: viewModel.address) { _ in
+            isButtonEnabled = !viewModel.address.isEmpty
+        }
+        .onChange(of: viewModel.currentStep) { _ in
+            switch viewModel.currentStep {
+            case 1:
+                isButtonEnabled = !viewModel.address.isEmpty
+            default:
+                isButtonEnabled = false
+            }
+        }
+        .fullScreenCover(isPresented: $showAddressWebView) {
+            AddressWebView(isPresented: $showAddressWebView, address: $viewModel.address)
         }
     }
 }

--- a/On-Dot/On-Dot/View/Onboarding/OnboardingViewModel.swift
+++ b/On-Dot/On-Dot/View/Onboarding/OnboardingViewModel.swift
@@ -5,6 +5,7 @@ final class OnboardingViewModel: ObservableObject {
     @Published var currentStep = 1
     @Published var hourText: String = ""
     @Published var minuteText: String = ""
+    @Published var address: String = ""
     
     let totalStep = 5
     

--- a/On-Dot/On-Dot/View/Onboarding/Step/OnboardingStep1View.swift
+++ b/On-Dot/On-Dot/View/Onboarding/Step/OnboardingStep1View.swift
@@ -14,12 +14,14 @@ struct OnboardingStep1View: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            (
-                Text("평소 ").foregroundColor(Color.gray0).font(OnDotTypo.titleMediumL) +
-                Text("외출 준비").foregroundColor(Color.green500).font(OnDotTypo.titleMediumL) +
-                Text("하는데\n얼마나 소요되나요?").foregroundColor(Color.gray0).font(OnDotTypo.titleMediumL)
-            )
-            .multilineTextAlignment(.leading)
+            VStack(alignment: .leading) {
+                HStack(spacing: 0) {
+                    Text("평소 ").font(OnDotTypo.titleMediumM).foregroundColor(Color.gray0)
+                    Text("외출 준비").font(OnDotTypo.titleMediumM).foregroundColor(Color.green500)
+                    Text("하는데").font(OnDotTypo.titleMediumM).foregroundColor(Color.gray0)
+                }
+                Text("얼마나 소요되나요?").font(OnDotTypo.titleMediumM).foregroundColor(Color.gray0)
+            }
             
             Spacer().frame(height: 16)
             

--- a/On-Dot/On-Dot/View/Onboarding/Step/OnboardingStep2View.swift
+++ b/On-Dot/On-Dot/View/Onboarding/Step/OnboardingStep2View.swift
@@ -1,0 +1,18 @@
+//
+//  OnboardingStep2View.swift
+//  On-Dot
+//
+//  Created by 현수 노트북 on 4/21/25.
+//
+
+import SwiftUI
+
+struct OnboardingStep2View: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    OnboardingStep2View()
+}

--- a/On-Dot/On-Dot/View/Onboarding/Step/OnboardingStep2View.swift
+++ b/On-Dot/On-Dot/View/Onboarding/Step/OnboardingStep2View.swift
@@ -8,11 +8,55 @@
 import SwiftUI
 
 struct OnboardingStep2View: View {
+    let address: String
+    
+    var onClickLocationSearchView: () -> Void
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 0) {
+                Text("주소")
+                    .font(OnDotTypo.titleMediumM)
+                    .foregroundColor(Color.green500)
+                Text("를 입력해 주세요.")
+                    .font(OnDotTypo.titleMediumM)
+                    .foregroundColor(Color.gray0)
+            }
+            
+            Spacer().frame(height: 16)
+            
+            Text("빠른 일정 등록에 꼭 필요한 정보예요.\n집 주소는 안전하게 저장되며 언제든 수정할 수 있어요.")
+                .font(OnDotTypo.bodyMediumR)
+                .foregroundStyle(Color.green300)
+            
+            Spacer().frame(height: 40)
+            
+            locationSearchView(address: address)
+        }
     }
-}
-
-#Preview {
-    OnboardingStep2View()
+    
+    @ViewBuilder
+    private func locationSearchView(
+        address: String
+    ) -> some View {
+        HStack(spacing: 8) {
+            Image("ic_search")
+                .resizable()
+                .frame(width: 20, height: 20)
+            
+            Text(address.isEmpty ? "도로명 주소" : address)
+                .font(OnDotTypo.bodyLargeR1)
+                .foregroundStyle(address.isEmpty ? Color.gray300 : Color.gray0)
+            
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 17)
+        .background(Color.gray700)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .onTapGesture {
+            onClickLocationSearchView()
+        }
+    }
 }

--- a/On-Dot/On-Dot/View/Utils/Address/AddressWebView.swift
+++ b/On-Dot/On-Dot/View/Utils/Address/AddressWebView.swift
@@ -1,0 +1,56 @@
+//
+//  AddressWebView.swift
+//  On-Dot
+//
+//  Created by 현수 노트북 on 4/22/25.
+//
+
+import SwiftUI
+import WebKit
+
+struct AddressWebView: UIViewRepresentable {
+    @Binding var isPresented: Bool
+    @Binding var address: String
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIView(context: Context) -> WKWebView {
+        let contentController = WKUserContentController()
+        contentController.add(context.coordinator, name: "addressSelected")
+
+        let config = WKWebViewConfiguration()
+        config.userContentController = contentController
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = context.coordinator
+
+        if let url = URL(string: "https://dh-crew.github.io/kakao-address-search/") {
+            webView.load(URLRequest(url: url))
+        }
+
+        return webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {}
+
+    class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+        var parent: AddressWebView
+
+        init(_ parent: AddressWebView) {
+            self.parent = parent
+        }
+
+        func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+            if let jsonString = message.body as? String {
+                if let data = jsonString.data(using: .utf8),
+                   let addressDict = try? JSONDecoder().decode(KaKaoAddressData.self, from: data) {
+                    parent.address = addressDict.roadAddress
+                    parent.isPresented = false
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## 이슈 번호
> 작업이 완료된 이슈의 번호를 기록해주세요.

- close #29 

## 작업내용
> 작업한 내용을 설명해주세요. 왜 수정했는지? 무엇을 구현했는지? 등등

- [x] OnboardingStep2View 구현
- [x] OnboardingStep1View -> OnboardingStep2View로 전환 로직 구현
- [x] AddressWebView 구현



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- 온보딩 과정에서 주소 입력 단계가 추가되어, 사용자가 주소를 입력할 수 있습니다.
	- 주소 검색을 위한 웹뷰가 도입되어 카카오 주소 검색 기능을 제공합니다.
	- 온보딩이 여러 단계로 구성되어 단계별 애니메이션 전환이 적용됩니다.

- **버그 수정**
	- 잘못된 폰트 이름 오타가 수정되었습니다.

- **스타일**
	- 온보딩 1단계 텍스트가 가독성 높게 분리 및 스타일이 개선되었습니다.

- **기타**
	- 앱 시작 시 기본 화면이 온보딩으로 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->