### PR TITLE
Feat: 온보딩 4단계 화면 구현

### DIFF
--- a/On-Dot/On-Dot/Model/Enum/Onboarding/ExpectationItem.swift
+++ b/On-Dot/On-Dot/Model/Enum/Onboarding/ExpectationItem.swift
@@ -1,0 +1,14 @@
+//
+//  ExpectationItem.swift
+//  On-Dot
+//
+//  Created by 현수 노트북 on 4/26/25.
+//
+
+import Foundation
+
+struct ExpectationItem: Identifiable, Equatable {
+    let id = UUID()
+    let imageName: String
+    let title: String
+}

--- a/On-Dot/On-Dot/Util/AppStorageManager.swift
+++ b/On-Dot/On-Dot/Util/AppStorageManager.swift
@@ -12,6 +12,9 @@ final class AppStorageManager {
     static let shared = AppStorageManager()
     
     private let alarmSoundKey = "selectedAlarmSound"
+    private let muteModeKey = "muteMode"
+    private let intervalKey = "interval"
+    private let repeatCountKey = "repeatCount"
     
     private init() {}
     
@@ -25,5 +28,31 @@ final class AppStorageManager {
     
     func clearSelectedSound() {
         UserDefaults.standard.removeObject(forKey: alarmSoundKey)
+    }
+    
+    func saveMuteMode(value: Bool) {
+        UserDefaults.standard.set(value, forKey: muteModeKey)
+    }
+    
+    func getMuteMode() -> Bool {
+        return UserDefaults.standard.bool(forKey: muteModeKey)
+    }
+    
+    func saveInterval(interval: AlarmInterval) {
+        UserDefaults.standard.set(interval.rawValue, forKey: intervalKey)
+    }
+    
+    func getInterval() -> AlarmInterval? {
+        let savedValue = UserDefaults.standard.integer(forKey: intervalKey)
+        return AlarmInterval(rawValue: savedValue)
+    }
+    
+    func saveRepeatCount(repeatCount: RepeatCount) {
+        UserDefaults.standard.set(repeatCount.rawValue, forKey: repeatCountKey)
+    }
+    
+    func getRepeatCount() -> RepeatCount? {
+        guard let savedValue = UserDefaults.standard.string(forKey: repeatCountKey) else { return nil }
+        return RepeatCount(rawValue: savedValue)
     }
 }

--- a/On-Dot/On-Dot/View/Onboarding/OnboardingView.swift
+++ b/On-Dot/On-Dot/View/Onboarding/OnboardingView.swift
@@ -103,12 +103,20 @@ struct OnboardingView: View {
             .onChange(of: viewModel.address) { _ in
                 isButtonEnabled = !viewModel.address.isEmpty
             }
+            .onChange(of: viewModel.isMuteMode) { _ in
+                isButtonEnabled = viewModel.isMuteMode || viewModel.selectedSound != nil
+            }
+            .onChange(of: viewModel.selectedSound) { _ in
+                isButtonEnabled = true
+            }
             .onChange(of: viewModel.currentStep) { _ in
                 switch viewModel.currentStep {
                 case 1:
                     isButtonEnabled = !viewModel.hourText.isEmpty || !viewModel.minuteText.isEmpty
                 case 2:
                     isButtonEnabled = !viewModel.address.isEmpty
+                case 3:
+                    isButtonEnabled = (viewModel.isMuteMode || viewModel.selectedSound != nil) && (!viewModel.isDelayMode)
                 default:
                     isButtonEnabled = false
                 }

--- a/On-Dot/On-Dot/View/Onboarding/OnboardingView.swift
+++ b/On-Dot/On-Dot/View/Onboarding/OnboardingView.swift
@@ -70,6 +70,17 @@ struct OnboardingView: View {
                                     removal: .move(edge: .leading).combined(with: .opacity)
                                 )
                             )
+                        } else if viewModel.currentStep == 4 {
+                            OnboardingStep4View(
+                                selectedItem: $viewModel.selectedExpectationItem,
+                                gridItems: viewModel.gridItems
+                            )
+                            .transition(
+                                .asymmetric(
+                                    insertion: .move(edge: .trailing).combined(with: .opacity),
+                                    removal: .move(edge: .leading).combined(with: .opacity)
+                                )
+                            )
                         }
                     }
                     .animation(.easeInOut, value: viewModel.currentStep)
@@ -109,6 +120,9 @@ struct OnboardingView: View {
             .onChange(of: viewModel.selectedSound) { _ in
                 isButtonEnabled = true
             }
+            .onChange(of: viewModel.selectedExpectationItem) { _ in
+                isButtonEnabled = viewModel.selectedExpectationItem != nil
+            }
             .onChange(of: viewModel.currentStep) { _ in
                 switch viewModel.currentStep {
                 case 1:
@@ -117,6 +131,8 @@ struct OnboardingView: View {
                     isButtonEnabled = !viewModel.address.isEmpty
                 case 3:
                     isButtonEnabled = (viewModel.isMuteMode || viewModel.selectedSound != nil) && (!viewModel.isDelayMode)
+                case 4:
+                    isButtonEnabled = viewModel.selectedExpectationItem != nil
                 default:
                     isButtonEnabled = false
                 }

--- a/On-Dot/On-Dot/View/Onboarding/OnboardingViewModel.swift
+++ b/On-Dot/On-Dot/View/Onboarding/OnboardingViewModel.swift
@@ -42,6 +42,7 @@ final class OnboardingViewModel: ObservableObject {
     
     func onClickButton() {
         if currentStep < 5 {
+            if currentStep == 3 { saveAlarmSettings() }
             currentStep += 1
         } else if currentStep == 5 {
             // TODO: 온보딩 완료 메서드 호출
@@ -49,8 +50,17 @@ final class OnboardingViewModel: ObservableObject {
     }
     
     func saveAlarmSettings() {
-        guard let sound = selectedSound else { return }
+        appStorageManager.saveMuteMode(value: isMuteMode)
         
-        appStorageManager.saveSelectedSound(fileName: sound.fileName)
+        if !isMuteMode {
+            if let sound = selectedSound {
+                appStorageManager.saveSelectedSound(fileName: sound.fileName)
+            }
+        }
+        
+        if isDelayMode {
+            appStorageManager.saveInterval(interval: selectedInterval)
+            appStorageManager.saveRepeatCount(repeatCount: selectedRepeatCount)
+        }
     }
 }

--- a/On-Dot/On-Dot/View/Onboarding/OnboardingViewModel.swift
+++ b/On-Dot/On-Dot/View/Onboarding/OnboardingViewModel.swift
@@ -40,6 +40,16 @@ final class OnboardingViewModel: ObservableObject {
     let intervalList: [AlarmInterval] = AlarmInterval.allCases
     let repeatCountList: [RepeatCount] = RepeatCount.allCases
     
+    // MARK: OnboardingStep4View
+    @Published var selectedExpectationItem: ExpectationItem?
+    let gridItems = [
+        ExpectationItem(imageName: "ic_hurry_up", title: "지각방지"),
+        ExpectationItem(imageName: "ic_mind_peace", title: "신경 쓰임 해소"),
+        ExpectationItem(imageName: "ic_calendar_check", title: "간편한 일정 관리"),
+        ExpectationItem(imageName: "ic_alarm_clock", title: "정확한 출발 타이밍 알림")
+    ]
+    
+    // MARK: Handler
     func onClickButton() {
         if currentStep < 5 {
             if currentStep == 3 { saveAlarmSettings() }

--- a/On-Dot/On-Dot/View/Onboarding/Step/OnboardingStep4View.swift
+++ b/On-Dot/On-Dot/View/Onboarding/Step/OnboardingStep4View.swift
@@ -1,0 +1,18 @@
+//
+//  OnboardingStep4View.swift
+//  On-Dot
+//
+//  Created by 현수 노트북 on 4/26/25.
+//
+
+import SwiftUI
+
+struct OnboardingStep4View: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    OnboardingStep4View()
+}

--- a/On-Dot/On-Dot/View/Onboarding/Step/OnboardingStep4View.swift
+++ b/On-Dot/On-Dot/View/Onboarding/Step/OnboardingStep4View.swift
@@ -8,11 +8,74 @@
 import SwiftUI
 
 struct OnboardingStep4View: View {
+    @Binding var selectedItem: ExpectationItem?
+    
+    let gridItems: [ExpectationItem]
+    
+    private let columns = [
+        GridItem(.flexible(), spacing: 17),
+        GridItem(.flexible(), spacing: 17)
+    ]
+    
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("ONDOT을 사용하면서")
+                    .font(OnDotTypo.titleMediumM)
+                    .foregroundColor(Color.gray0)
+                HStack(spacing: 0) {
+                    Text("어떤 것을 가장 ")
+                        .font(OnDotTypo.titleMediumM)
+                        .foregroundColor(Color.gray0)
+                    Text("기대")
+                        .font(OnDotTypo.titleMediumM)
+                        .foregroundColor(Color.green500)
+                    Text("하나요?")
+                        .font(OnDotTypo.titleMediumM)
+                        .foregroundColor(Color.gray0)
+                }
+            }
+            
+            Spacer().frame(height: 16)
+            
+            Text("한 개의 항목만 선택이 가능해요.")
+                .font(OnDotTypo.bodyMediumR)
+                .foregroundStyle(Color.green300)
+            
+            Spacer().frame(height: 40)
+            
+            LazyVGrid(columns: columns, spacing: 16) {
+                ForEach(gridItems) { item in
+                    GridItemView(item: item, isSelected: selectedItem == item)
+                        .onTapGesture {
+                            selectedItem = item
+                        }
+                }
+            }
+        }
     }
 }
 
-#Preview {
-    OnboardingStep4View()
+private struct GridItemView: View {
+    let item: ExpectationItem
+    let isSelected: Bool
+    
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(item.imageName)
+            
+            Text(item.title)
+                .font(OnDotTypo.bodyMediumR)
+                .foregroundColor(Color.gray0)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 28)
+        .padding(.bottom, 16)
+        .background(Color.gray600)
+        .clipShape(RoundedRectangle(cornerRadius: 12))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(isSelected ? Color.green600 : Color.clear, lineWidth: 1)
+        )
+    }
 }


### PR DESCRIPTION
## 이슈 번호
> 작업이 완료된 이슈의 번호를 기록해주세요.

- close #33 

## 작업내용
> 작업한 내용을 설명해주세요. 왜 수정했는지? 무엇을 구현했는지? 등등

- [x] OnboardingStep4View 구현
- [x] step3 -> step4 전환 로직 구현

## 결과물
> 구현한 것 스크린샷 또는 영상 또는 gif 형태로 올려주세요.

![image](https://github.com/user-attachments/assets/9fc2e85f-d66a-4b01-996b-df45228847fb)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 온보딩 과정에 기대 항목을 선택하는 4단계가 추가되었습니다.
    - 기대 항목을 그리드 형태로 보여주고 하나를 선택할 수 있는 화면이 도입되었습니다.
    - 알람 설정에서 무음 모드, 인터벌, 반복 횟수 저장 및 불러오기 기능이 추가되었습니다.

- **개선 사항**
    - 온보딩 단계별 버튼 활성화 조건이 개선되어, 각 단계별로 더 정확하게 버튼이 활성화됩니다.
    - 알람 설정 저장 로직이 개선되어, 무음 모드 및 선택된 사운드, 딜레이 모드에 따라 설정이 저장됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->