### PR TITLE
Feat: 고객센터, 서비스 정책 화면 구현

### DIFF
--- a/On-Dot/On-Dot/View/My/MyPageView.swift
+++ b/On-Dot/On-Dot/View/My/MyPageView.swift
@@ -42,7 +42,7 @@ struct MyPageView: View {
                         content2: "서비스 이용약관",
                         content3: "개인정보 처리 방침",
                         onClickContent1: {
-                            if let url = URL(string: "http://pf.kakao.com/_xfdLfn/chat") {
+                            if let url = URL(string: viewModel.customerServiceChatLink) {
                                 UIApplication.shared.open(url, options: [:], completionHandler: nil)
                             }
                         },
@@ -90,12 +90,12 @@ struct MyPageView: View {
                 }
             }
             .fullScreenCover(isPresented: $viewModel.isPolicyViewPresented) {
-                if let url = URL(string: "https://ondotdh.notion.site/Ondot-1e1d775a8a04802495c7cc44cac766cc?pvs=4") {
+                if let url = URL(string: viewModel.privacyPolicyLink) {
                     WebViewScreen(url: url)
                 }
             }
             .fullScreenCover(isPresented: $viewModel.isTermsViewPresented) {
-                if let url = URL(string: "https://ondotdh.notion.site/Ondot-1e1d775a8a04808782acc823d631d74b?pvs=4") {
+                if let url = URL(string: viewModel.termsLink) {
                     WebViewScreen(url: url)
                 }
             }

--- a/On-Dot/On-Dot/View/My/MyPageView.swift
+++ b/On-Dot/On-Dot/View/My/MyPageView.swift
@@ -39,7 +39,15 @@ struct MyPageView: View {
                     MyPageMenuView(
                         title: "도움",
                         content1: "고객센터",
-                        content2: "서비스 정책"
+                        content2: "서비스 이용약관",
+                        content3: "개인정보 처리 방침",
+                        onClickContent1: {
+                            if let url = URL(string: "http://pf.kakao.com/_xfdLfn/chat") {
+                                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                            }
+                        },
+                        onClickContent2: { viewModel.isPolicyViewPresented = true },
+                        onClickContent3: { viewModel.isTermsViewPresented = true }
                     )
                     
                     Spacer().frame(height: 16)
@@ -81,6 +89,16 @@ struct MyPageView: View {
                     .enableSwipeBack()
                 }
             }
+            .fullScreenCover(isPresented: $viewModel.isPolicyViewPresented) {
+                if let url = URL(string: "https://ondotdh.notion.site/Ondot-1e1d775a8a04802495c7cc44cac766cc?pvs=4") {
+                    WebViewScreen(url: url)
+                }
+            }
+            .fullScreenCover(isPresented: $viewModel.isTermsViewPresented) {
+                if let url = URL(string: "https://ondotdh.notion.site/Ondot-1e1d775a8a04808782acc823d631d74b?pvs=4") {
+                    WebViewScreen(url: url)
+                }
+            }
         }
     }
 }
@@ -89,9 +107,11 @@ struct MyPageMenuView: View {
     let title: String
     let content1: String
     let content2: String
+    var content3: String = ""
     
     var onClickContent1: () -> Void = {}
     var onClickContent2: () -> Void = {}
+    var onClickContent3: () -> Void = {}
     
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -111,6 +131,12 @@ struct MyPageMenuView: View {
             Spacer().frame(height: 20)
             
             menuItem(content: content2, onClickContent: onClickContent2)
+            
+            if !content3.isEmpty {
+                Spacer().frame(height: 20)
+                
+                menuItem(content: content3, onClickContent: onClickContent3)
+            }
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 16)

--- a/On-Dot/On-Dot/View/My/MyPageViewModel.swift
+++ b/On-Dot/On-Dot/View/My/MyPageViewModel.swift
@@ -19,6 +19,9 @@ final class MyPageViewModel: ObservableObject {
     // MARK: - MyPageView State
     @Published var isPolicyViewPresented: Bool = false
     @Published var isTermsViewPresented: Bool = false
+    let customerServiceChatLink = "http://pf.kakao.com/_xfdLfn/chat"
+    let privacyPolicyLink = "https://ondotdh.notion.site/Ondot-1e1d775a8a04802495c7cc44cac766cc?pvs=4"
+    let termsLink = "https://ondotdh.notion.site/Ondot-1e1d775a8a04808782acc823d631d74b?pvs=4"
     
     // MARK: - HomeAddressSettingView State
     var homeAddress: HomeAddressInfo = .placeholder

--- a/On-Dot/On-Dot/View/My/MyPageViewModel.swift
+++ b/On-Dot/On-Dot/View/My/MyPageViewModel.swift
@@ -16,6 +16,10 @@ final class MyPageViewModel: ObservableObject {
         self.locationRepository = locationRepository
     }
     
+    // MARK: - MyPageView State
+    @Published var isPolicyViewPresented: Bool = false
+    @Published var isTermsViewPresented: Bool = false
+    
     // MARK: - HomeAddressSettingView State
     var homeAddress: HomeAddressInfo = .placeholder
     

--- a/On-Dot/On-Dot/View/Utils/WebView/OnDotWebView.swift
+++ b/On-Dot/On-Dot/View/Utils/WebView/OnDotWebView.swift
@@ -1,0 +1,41 @@
+//
+//  OnDotWebView.swift
+//  On-Dot
+//
+//  Created by 현수 노트북 on 4/30/25.
+//
+
+import SwiftUI
+import WebKit
+
+struct OnDotWebView: UIViewRepresentable {
+    let url: URL
+    
+    func makeUIView(context: Context) -> WKWebView {
+        WKWebView()
+    }
+    
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        let request = URLRequest(url: url)
+        uiView.load(request)
+    }
+}
+
+struct WebViewScreen: View {
+    let url: URL
+    @Environment(\.presentationMode) var presentationMode
+    
+    var body: some View {
+        NavigationView {
+            OnDotWebView(url: url)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button("닫기") {
+                            presentationMode.wrappedValue.dismiss()
+                        }
+                    }
+                }
+        }
+    }
+}


### PR DESCRIPTION
## 이슈 번호
> 작업이 완료된 이슈의 번호를 기록해주세요.

- close #45 

## 작업내용
> 작업한 내용을 설명해주세요. 왜 수정했는지? 무엇을 구현했는지? 등등

- [x] 고객센터 메뉴 클릭 시 오픈채팅방으로 이동 로직 구현
- [x] 서비스 정책 클릭 시 노션 렌더링
- [x] OnDotWebView 구현



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - "도움" 메뉴에 "서비스 이용약관" 및 "개인정보 처리 방침" 항목이 추가되어 각 항목 선택 시 전체 화면 웹뷰로 관련 문서를 확인할 수 있습니다.
  - "고객센터" 메뉴 선택 시 카카오톡 채팅 URL로 연결됩니다.
  - 전체 화면 웹뷰에서 문서 확인 시 닫기 버튼으로 손쉽게 화면을 종료할 수 있습니다.

- **개선 사항**
  - 메뉴 UI가 세 번째 항목까지 지원하도록 확장되어, 추가 메뉴 항목이 기존 레이아웃과 일관되게 표시됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->