### PR TITLE
Feat/53 schedule api

### DIFF
--- a/On-Dot/On-Dot/DesignSystem/Components/Composite/BottomSheet/OnDotBottomSheet.swift
+++ b/On-Dot/On-Dot/DesignSystem/Components/Composite/BottomSheet/OnDotBottomSheet.swift
@@ -12,6 +12,14 @@ struct OnDotBottomSheet<Content: View>: View {
     
     let content: Content
     
+    init(
+        onDismissRequest: @escaping () -> Void,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.onDismissRequest = onDismissRequest
+        self.content = content()
+    }
+    
     var body: some View {
         ZStack {
             Color.black.opacity(0.4)
@@ -22,9 +30,9 @@ struct OnDotBottomSheet<Content: View>: View {
                 Spacer()
                 
                 content
-                    .frame(maxWidth: .infinity)
+                    .frame(maxWidth: .infinity, maxHeight: 600)
                     .padding(.horizontal, 22)
-                    .padding(.top, 32)
+                    .padding(.top, 16)
                     .padding(.bottom, 16)
                     .background(
                         Color.gray700

--- a/On-Dot/On-Dot/DesignSystem/Components/Composite/BottomSheet/OnDotBottomSheet.swift
+++ b/On-Dot/On-Dot/DesignSystem/Components/Composite/BottomSheet/OnDotBottomSheet.swift
@@ -1,0 +1,53 @@
+//
+//  OnDotBottomSheet.swift
+//  On-Dot
+//
+//  Created by 현수 노트북 on 5/3/25.
+//
+
+import SwiftUI
+
+struct OnDotBottomSheet<Content: View>: View {
+    var onDismissRequest: () -> Void
+    
+    let content: Content
+    
+    var body: some View {
+        ZStack {
+            Color.black.opacity(0.4)
+                .ignoresSafeArea()
+                .onTapGesture { onDismissRequest() }
+            
+            VStack {
+                Spacer()
+                
+                content
+                    .frame(maxWidth: .infinity)
+                    .padding(.horizontal, 22)
+                    .padding(.top, 32)
+                    .padding(.bottom, 16)
+                    .background(
+                        Color.gray700
+                            .clipShape(
+                                RoundedCorner(radius: 20, corners: [.topLeft, .topRight])
+                            )
+                    )
+            }
+        }
+    }
+}
+
+private On-Dot/On-Dot/DesignSystem/Components/Composite/BottomSheet/OnDotBottomSheet.swift
+struct RoundedCorner: Shape {
+    var radius: CGFloat
+    var corners: UIRectCorner
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(
+            roundedRect: rect,
+            byRoundingCorners: corners,
+            cornerRadii: CGSize(width: radius, height: radius)
+        )
+        return Path(path.cgPath)
+    }
+}

--- a/On-Dot/On-Dot/DesignSystem/Components/Composite/BottomSheet/OnDotBottomSheet.swift
+++ b/On-Dot/On-Dot/DesignSystem/Components/Composite/BottomSheet/OnDotBottomSheet.swift
@@ -37,8 +37,7 @@ struct OnDotBottomSheet<Content: View>: View {
     }
 }
 
-private On-Dot/On-Dot/DesignSystem/Components/Composite/BottomSheet/OnDotBottomSheet.swift
-struct RoundedCorner: Shape {
+private struct RoundedCorner: Shape {
     var radius: CGFloat
     var corners: UIRectCorner
 

--- a/On-Dot/On-Dot/DesignSystem/Components/Composite/CreateSchedule/General/DateTimeSettingView.swift
+++ b/On-Dot/On-Dot/DesignSystem/Components/Composite/CreateSchedule/General/DateTimeSettingView.swift
@@ -19,8 +19,8 @@ struct DateTimeSettingView: View {
     @Binding var hour: Int
     @Binding var minute: Int
     
-    var onClickSelectedDateView: () -> Void
-    var onClickSelectedTimeView: () -> Void
+    var onClickSelectedDateView: () -> Void = {}
+    var onClickSelectedTimeView: () -> Void = {}
     var increaseMonth: () -> Void
     var decreaseMonth: () -> Void
     var onClickDate: (Date) -> Void

--- a/On-Dot/On-Dot/DesignSystem/Components/Composite/CreateSchedule/General/RepeatSettingView.swift
+++ b/On-Dot/On-Dot/DesignSystem/Components/Composite/CreateSchedule/General/RepeatSettingView.swift
@@ -14,10 +14,10 @@ struct RepeatSettingView: View {
     var activeCheckChip: Int?
     var activeWeekdays: Set<Int>
     
-    var onClickToggle: () -> Void
+    var onClickToggle: () -> Void = {}
     var onClickCheckTextChip: (Int) -> Void
     var onClickTextChip: (Int) -> Void
-    var onClickCheckBox: () -> Void
+    var onClickCheckBox: () -> Void = {}
     
     var body: some View {
         VStack(spacing: 0) {

--- a/On-Dot/On-Dot/DesignSystem/Components/Composite/FromToLocationView.swift
+++ b/On-Dot/On-Dot/DesignSystem/Components/Composite/FromToLocationView.swift
@@ -44,13 +44,6 @@ struct FromToLocationView: View {
     
     var body: some View {
         HStack(spacing: 0) {
-//            Spacer().frame(width: 10)
-            
-//            Image("ic_swap_vertical")
-//                .onTapGesture { swapLocation() }
-//            
-//            Spacer().frame(width: 10)
-            
             VStack(alignment: .leading, spacing: 0) {
                 locationView(image: "ic_from_location", title: "출발지", content: $fromLocation, focusType: .from)
                 Spacer().frame(height: 16)
@@ -120,10 +113,9 @@ struct FromToLocationView: View {
                     Image("ic_close")
                         .resizable()
                         .renderingMode(.template)
-                        .frame(width: 20, height: 20)
+                        .frame(width: 16, height: 16)
                         .foregroundStyle(closeButtonColor)
                 }
-                Spacer().frame(width: 20)
             }
         }
         .frame(maxWidth: .infinity)

--- a/On-Dot/On-Dot/DesignSystem/Components/Composite/Home/RemainingTimeView.swift
+++ b/On-Dot/On-Dot/DesignSystem/Components/Composite/Home/RemainingTimeView.swift
@@ -8,25 +8,36 @@
 import SwiftUI
 
 struct RemainingTimeView: View {
-    var day: Int = 0
-    var hour: Int = 0
-    var minute: Int = 0
+    var alarmDate: Date?
     
     var body: some View {
-        Text(formatRemainingTimeText())
+        Text(formattedRemainingTime())
             .font(OnDotTypo.titleMediumSB)
             .foregroundStyle(Color.gray0)
     }
     
-    private func formatRemainingTimeText() -> String {
-        if day == 0 && hour == 0 && minute == 0 {
-            return "곧 알람이 울려요"
-        }
-        
-        if day == -1 && hour == -1 && minute == -1 {
+    private func formattedRemainingTime() -> String {
+        guard let alarmDate else {
             return "등록된 알람이 없어요"
         }
+
+        let now = Date()
+        let interval = alarmDate.timeIntervalSince(now)
         
-        return "\(day)일 \(hour)시간 \(minute)분 후에 울려요"
+        if interval <= 0 {
+            return "곧 알람이 울려요"
+        }
+
+        let totalMinutes = Int(interval) / 60
+        let days = totalMinutes / (24 * 60)
+        let hours = (totalMinutes % (24 * 60)) / 60
+        let minutes = totalMinutes % 60
+
+        if days == 0 && hours == 0 && minutes == 0 {
+            return "곧 알람이 울려요"
+        }
+
+        return "\(days)일 \(hours)시간 \(minutes)분 후에 울려요"
     }
 }
+

--- a/On-Dot/On-Dot/DesignSystem/Components/Composite/Home/ScheduleAlarmListItemView.swift
+++ b/On-Dot/On-Dot/DesignSystem/Components/Composite/Home/ScheduleAlarmListItemView.swift
@@ -17,8 +17,8 @@ struct ScheduleAlarmListItemView: View {
             ScheduleNameDateView(item: item)
             
             ScheduleTimeAlarmView(
-                meridiem: DateFormatterUtil.formatMeridiem(item.appointmentAt),
-                hourMinute: DateFormatterUtil.formatHourMinute(item.appointmentAt),
+                meridiem: DateFormatterUtil.formatMeridiem(item.departureTriggeredAt),
+                hourMinute: DateFormatterUtil.formatHourMinute(item.departureTriggeredAt),
                 isEnabled: item.isEnabled,
                 onClickToggle: onClickToggle
             )

--- a/On-Dot/On-Dot/DesignSystem/Components/Composite/Home/ScheduleAlarmListItemView.swift
+++ b/On-Dot/On-Dot/DesignSystem/Components/Composite/Home/ScheduleAlarmListItemView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ScheduleAlarmListItemView: View {
-    let item: ScheduleModel
+    let item: HomeScheduleInfo
     
     var onClickToggle: (Bool) -> Void
 
@@ -42,7 +42,7 @@ struct ScheduleAlarmListItemView: View {
 }
 
 private struct ScheduleNameDateView: View {
-    var item: ScheduleModel
+    var item: HomeScheduleInfo
     
     var body: some View {
         HStack(alignment: .center) {

--- a/On-Dot/On-Dot/DesignSystem/Components/Composite/Toast/OnDotToastView.swift
+++ b/On-Dot/On-Dot/DesignSystem/Components/Composite/Toast/OnDotToastView.swift
@@ -11,12 +11,13 @@ struct OnDotToastView: View {
     let isDelete: Bool
     var minute: Int = 0
     var dateTime: String = ""
+    var message: String = ""
     
     var onClickBtnRevert: () -> Void = {}
     
     var body: some View {
         HStack(alignment: .center, spacing: 0) {
-            Image(isDelete ? "ic_check_bg_red" : "ic_check_bg_green")
+            Image(isDelete ? "ic_check_bg_red" : message.isEmpty ? "ic_check_bg_green" : "ic_check_bg_red")
                 .resizable()
                 .frame(width: 16, height: 16)
             
@@ -35,9 +36,9 @@ struct OnDotToastView: View {
                         .foregroundStyle(Color.gray200)
                 }
             } else {
-                Text("소요시간이 \(minute)분이 예상되어,\n[\(dateTime)]에 알람이 설정되었습니다.")
+                Text(message.isEmpty ? "소요시간이 \(minute)분이 예상되어,\n[\(dateTime)]에 알람이 설정되었습니다." : message)
                     .font(OnDotTypo.bodyLargeSB)
-                    .foregroundStyle(Color.green700)
+                    .foregroundStyle(message.isEmpty ? Color.green700 : Color.red)
                 
                 Spacer()
             }
@@ -56,6 +57,7 @@ private struct ToastModifier: ViewModifier {
     let isDelete: Bool
     var minute: Int = 0
     var dateTime: String = ""
+    var message: String = ""
     
     var onClickBtnRevert: () -> Void
 
@@ -66,7 +68,7 @@ private struct ToastModifier: ViewModifier {
             if isPresented {
                 VStack {
                     Spacer()
-                    OnDotToastView(isDelete: isDelete, minute: minute, dateTime: dateTime, onClickBtnRevert: onClickBtnRevert)
+                    OnDotToastView(isDelete: isDelete, minute: minute, dateTime: dateTime, message: message, onClickBtnRevert: onClickBtnRevert)
                         .transition(.move(edge: .bottom).combined(with: .opacity))
                         .padding(.bottom, 40)
                         .onAppear {
@@ -86,10 +88,11 @@ extension View {
     func toast(
         isPresented: Binding<Bool>,
         isDelete: Bool,
-        minute: Int,
-        dateTime: String,
-        onClickBtnRevert: @escaping () -> Void
+        minute: Int = 0,
+        dateTime: String = "",
+        message: String = "",
+        onClickBtnRevert: @escaping () -> Void = {}
     ) -> some View {
-        self.modifier(ToastModifier(isPresented: isPresented, isDelete: isDelete, minute: minute, dateTime: dateTime, onClickBtnRevert: onClickBtnRevert))
+        self.modifier(ToastModifier(isPresented: isPresented, isDelete: isDelete, minute: minute, dateTime: dateTime, message: message, onClickBtnRevert: onClickBtnRevert))
     }
 }

--- a/On-Dot/On-Dot/Model/Alarm/CalculateRequest.swift
+++ b/On-Dot/On-Dot/Model/Alarm/CalculateRequest.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 struct CalculateRequest: Codable {
-    let appointmentAt: String
+    let appointmentAt: Date
     let startLongitude: Double
     let startLatitude: Double
     let endLongitude: Double

--- a/On-Dot/On-Dot/Model/Schedule/HomeScheduleInfo.swift
+++ b/On-Dot/On-Dot/Model/Schedule/HomeScheduleInfo.swift
@@ -7,12 +7,13 @@
 
 import Foundation
 
-struct ScheduleModel: Codable, Identifiable {
+struct HomeScheduleInfo: Codable, Identifiable {
     let id: Int
     var title: String
     var isRepeat: Bool
     var repeatDays: [Int]
     let appointmentAt: Date
+    let nextAlarmAt: Date
     let preparationTriggeredAt: Date?
     let departureTriggeredAt: Date
     var isEnabled: Bool
@@ -21,19 +22,21 @@ struct ScheduleModel: Codable, Identifiable {
         case id = "scheduleId"
         case title = "scheduleTitle"
         case isRepeat
-        case repeatDays = "repeatDay"
+        case repeatDays
         case appointmentAt
+        case nextAlarmAt
         case preparationTriggeredAt
         case departureTriggeredAt
         case isEnabled
     }
     
-    static let placeholder = ScheduleModel(
+    static let placeholder = HomeScheduleInfo(
         id: -1,
         title: "",
         isRepeat: false,
         repeatDays: [],
         appointmentAt: Date(),
+        nextAlarmAt: Date(),
         preparationTriggeredAt: nil,
         departureTriggeredAt: Date(),
         isEnabled: false

--- a/On-Dot/On-Dot/Model/Schedule/HomeScheduleResponse.swift
+++ b/On-Dot/On-Dot/Model/Schedule/HomeScheduleResponse.swift
@@ -1,0 +1,22 @@
+//
+//  HomeScheduleResponse.swift
+//  On-Dot
+//
+//  Created by 현수 노트북 on 5/2/25.
+//
+
+import Foundation
+
+struct HomeScheduleResponse: Codable {
+    let isOnboardingCompleted: Bool
+    let earliestAlarmAt: Date
+    let hasNext: Bool
+    let scheduleList: [HomeScheduleInfo]
+    
+    enum CodingKeys: String, CodingKey {
+        case isOnboardingCompleted
+        case earliestAlarmAt = "earliestAlarmTime"
+        case hasNext
+        case scheduleList
+    }
+}

--- a/On-Dot/On-Dot/Model/Schedule/HomeScheduleResponse.swift
+++ b/On-Dot/On-Dot/Model/Schedule/HomeScheduleResponse.swift
@@ -12,11 +12,4 @@ struct HomeScheduleResponse: Codable {
     let earliestAlarmAt: Date
     let hasNext: Bool
     let scheduleList: [HomeScheduleInfo]
-    
-    enum CodingKeys: String, CodingKey {
-        case isOnboardingCompleted
-        case earliestAlarmAt = "earliestAlarmTime"
-        case hasNext
-        case scheduleList
-    }
 }

--- a/On-Dot/On-Dot/Model/Schedule/ScheduleInfo.swift
+++ b/On-Dot/On-Dot/Model/Schedule/ScheduleInfo.swift
@@ -5,11 +5,13 @@
 //  Created by 현수 노트북 on 4/15/25.
 //
 
+import Foundation
+
 struct ScheduleInfo: Codable {
     var title: String
     var isRepeat: Bool
     var repeatDays: [Int]
-    var appointmentAt: String
+    var appointmentAt: Date
     var departurePlace: LocationInfo
     var arrivalPlace: LocationInfo
     var preparationAlarm: AlarmInfo
@@ -21,7 +23,7 @@ extension ScheduleInfo {
         title: "스터디 모임",
         isRepeat: true,
         repeatDays: [2, 4, 6],
-        appointmentAt: "2025-05-10T19:00:00",
+        appointmentAt: Date(),
         departurePlace: LocationInfo(
             title: "집",
             roadAddress: "서울특별시 강남구 테헤란로 123",

--- a/On-Dot/On-Dot/Network/KeyChainManager.swift
+++ b/On-Dot/On-Dot/Network/KeyChainManager.swift
@@ -25,7 +25,7 @@ final class KeychainManager {
             kSecValueData: data
         ] as CFDictionary
         
-        let deleteStatus = SecItemDelete(query)
+        _ = SecItemDelete(query)
         let addStatus = SecItemAdd(query, nil)
         
         if addStatus != errSecSuccess {

--- a/On-Dot/On-Dot/Network/NetworkManager.swift
+++ b/On-Dot/On-Dot/Network/NetworkManager.swift
@@ -28,7 +28,14 @@ final class NetworkManager {
             }
 
             do {
-                return try JSONDecoder().decode(T.self, from: data)
+                let decoder = JSONDecoder()
+                let formatter = DateFormatter()
+                formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+                formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+                formatter.locale = Locale(identifier: "ko_KR")
+                decoder.dateDecodingStrategy = .formatted(formatter)
+
+                return try decoder.decode(T.self, from: data)
             } catch {
                 throw error
             }

--- a/On-Dot/On-Dot/Network/Repository/ScheduleRepository.swift
+++ b/On-Dot/On-Dot/Network/Repository/ScheduleRepository.swift
@@ -8,4 +8,5 @@
 protocol ScheduleRepository {
     func createSchedule(schedule: ScheduleInfo) async throws -> Void
     func getSchedules() async throws -> HomeScheduleResponse
+    func deleteSchedule(id: Int) async throws -> Void
 }

--- a/On-Dot/On-Dot/Network/Repository/ScheduleRepository.swift
+++ b/On-Dot/On-Dot/Network/Repository/ScheduleRepository.swift
@@ -7,4 +7,5 @@
 
 protocol ScheduleRepository {
     func createSchedule(schedule: ScheduleInfo) async throws -> Void
+//    func getSchedules() async throws ->
 }

--- a/On-Dot/On-Dot/Network/Repository/ScheduleRepository.swift
+++ b/On-Dot/On-Dot/Network/Repository/ScheduleRepository.swift
@@ -7,5 +7,5 @@
 
 protocol ScheduleRepository {
     func createSchedule(schedule: ScheduleInfo) async throws -> Void
-//    func getSchedules() async throws ->
+    func getSchedules() async throws -> HomeScheduleResponse
 }

--- a/On-Dot/On-Dot/Network/Repository/ScheduleRepository.swift
+++ b/On-Dot/On-Dot/Network/Repository/ScheduleRepository.swift
@@ -10,4 +10,5 @@ protocol ScheduleRepository {
     func getSchedules() async throws -> HomeScheduleResponse
     func deleteSchedule(id: Int) async throws -> Void
     func getScheduleDetail(id: Int) async throws -> ScheduleInfo
+    func editSchedule(id: Int, schedule: ScheduleInfo) async throws -> Void
 }

--- a/On-Dot/On-Dot/Network/Repository/ScheduleRepository.swift
+++ b/On-Dot/On-Dot/Network/Repository/ScheduleRepository.swift
@@ -9,4 +9,5 @@ protocol ScheduleRepository {
     func createSchedule(schedule: ScheduleInfo) async throws -> Void
     func getSchedules() async throws -> HomeScheduleResponse
     func deleteSchedule(id: Int) async throws -> Void
+    func getScheduleDetail(id: Int) async throws -> ScheduleInfo
 }

--- a/On-Dot/On-Dot/Network/RepositoryImpl/ScheduleRepositoryImpl.swift
+++ b/On-Dot/On-Dot/Network/RepositoryImpl/ScheduleRepositoryImpl.swift
@@ -25,4 +25,8 @@ final class ScheduleRepositoryImpl: ScheduleRepository {
     func deleteSchedule(id: Int) async throws {
         _ = try await networkManager.request(type: EmptyResponse.self, api: .deleteSchedule(scheduleId: id))
     }
+    
+    func getScheduleDetail(id: Int) async throws -> ScheduleInfo {
+        return try await networkManager.request(type: ScheduleInfo.self, api: .getScheduleDetail(scheduleId: id))
+    }
 }

--- a/On-Dot/On-Dot/Network/RepositoryImpl/ScheduleRepositoryImpl.swift
+++ b/On-Dot/On-Dot/Network/RepositoryImpl/ScheduleRepositoryImpl.swift
@@ -21,4 +21,8 @@ final class ScheduleRepositoryImpl: ScheduleRepository {
     func getSchedules() async throws -> HomeScheduleResponse {
         return try await networkManager.request(type: HomeScheduleResponse.self, api: .getSchedules)
     }
+    
+    func deleteSchedule(id: Int) async throws {
+        _ = try await networkManager.request(type: EmptyResponse.self, api: .deleteSchedule(scheduleId: id))
+    }
 }

--- a/On-Dot/On-Dot/Network/RepositoryImpl/ScheduleRepositoryImpl.swift
+++ b/On-Dot/On-Dot/Network/RepositoryImpl/ScheduleRepositoryImpl.swift
@@ -29,4 +29,8 @@ final class ScheduleRepositoryImpl: ScheduleRepository {
     func getScheduleDetail(id: Int) async throws -> ScheduleInfo {
         return try await networkManager.request(type: ScheduleInfo.self, api: .getScheduleDetail(scheduleId: id))
     }
+    
+    func editSchedule(id: Int, schedule: ScheduleInfo) async throws {
+        _ = try await networkManager.request(type: EmptyResponse.self, api: .editSchedule(scheduleId: id, schedule: schedule))
+    }
 }

--- a/On-Dot/On-Dot/Network/RepositoryImpl/ScheduleRepositoryImpl.swift
+++ b/On-Dot/On-Dot/Network/RepositoryImpl/ScheduleRepositoryImpl.swift
@@ -17,4 +17,8 @@ final class ScheduleRepositoryImpl: ScheduleRepository {
     func createSchedule(schedule: ScheduleInfo) async throws {
         _ = try await networkManager.request(type: EmptyResponse.self, api: .createSchedule(schedule: schedule))
     }
+    
+    func getSchedules() async throws -> HomeScheduleResponse {
+        return try await networkManager.request(type: HomeScheduleResponse.self, api: .getSchedules)
+    }
 }

--- a/On-Dot/On-Dot/Network/Router.swift
+++ b/On-Dot/On-Dot/Network/Router.swift
@@ -18,6 +18,7 @@ enum Router: URLRequestConvertible {
     
     // MARK: Schedule
     case createSchedule(schedule: ScheduleInfo)
+    case getSchedules
     
     // MARK: Member
     case onboarding(onboardingRequest: OnboardingRequest)
@@ -29,7 +30,7 @@ enum Router: URLRequestConvertible {
     var method: HTTPMethod {
         switch self {
         case .login, .createSchedule, .calculate: .post
-        case .searchPlace: .get
+        case .searchPlace, .getSchedules: .get
         case .onboarding: .put
         }
     }
@@ -43,7 +44,7 @@ enum Router: URLRequestConvertible {
         case .searchPlace: "/places/search"
             
         // MARK: Schedule
-        case .createSchedule: "/schedules"
+        case .createSchedule, .getSchedules: "/schedules"
             
         // MARK: Member
         case .onboarding: "/members/onboarding"

--- a/On-Dot/On-Dot/Network/Router.swift
+++ b/On-Dot/On-Dot/Network/Router.swift
@@ -19,6 +19,7 @@ enum Router: URLRequestConvertible {
     // MARK: Schedule
     case createSchedule(schedule: ScheduleInfo)
     case getSchedules
+    case deleteSchedule(scheduleId: Int)
     
     // MARK: Member
     case onboarding(onboardingRequest: OnboardingRequest)
@@ -32,6 +33,7 @@ enum Router: URLRequestConvertible {
         case .login, .createSchedule, .calculate: .post
         case .searchPlace, .getSchedules: .get
         case .onboarding: .put
+        case .deleteSchedule: .delete
         }
     }
 
@@ -44,7 +46,7 @@ enum Router: URLRequestConvertible {
         case .searchPlace: "/places/search"
             
         // MARK: Schedule
-        case .createSchedule, .getSchedules: "/schedules"
+        case .createSchedule, .getSchedules, .deleteSchedule: "/schedules"
             
         // MARK: Member
         case .onboarding: "/members/onboarding"
@@ -84,6 +86,10 @@ enum Router: URLRequestConvertible {
         case .searchPlace(let query):
             return [
                 URLQueryItem(name: "query", value: query)
+            ]
+        case .deleteSchedule(let scheduleId):
+            return [
+                URLQueryItem(name: "scheduleId", value: String(scheduleId))
             ]
         default: return nil
         }

--- a/On-Dot/On-Dot/Network/Router.swift
+++ b/On-Dot/On-Dot/Network/Router.swift
@@ -21,6 +21,7 @@ enum Router: URLRequestConvertible {
     case getSchedules
     case deleteSchedule(scheduleId: Int)
     case getScheduleDetail(scheduleId: Int)
+    case editSchedule(scheduleId: Int, schedule: ScheduleInfo)
     
     // MARK: Member
     case onboarding(onboardingRequest: OnboardingRequest)
@@ -33,7 +34,7 @@ enum Router: URLRequestConvertible {
         switch self {
         case .login, .createSchedule, .calculate: .post
         case .searchPlace, .getSchedules, .getScheduleDetail: .get
-        case .onboarding: .put
+        case .onboarding, .editSchedule: .put
         case .deleteSchedule: .delete
         }
     }
@@ -49,6 +50,7 @@ enum Router: URLRequestConvertible {
         // MARK: Schedule
         case .createSchedule, .getSchedules: "/schedules"
         case .deleteSchedule(let scheduleId), .getScheduleDetail(let scheduleId): "/schedules/\(scheduleId)"
+        case .editSchedule(let scheduleId, _): "/schedules/\(scheduleId)"
             
         // MARK: Member
         case .onboarding: "/members/onboarding"
@@ -74,6 +76,8 @@ enum Router: URLRequestConvertible {
             return try? request.asDictionary()
         case .createSchedule(let request):
             return try? request.asDictionary()
+        case .editSchedule(_, let schedule):
+            return try? schedule.asDictionary()
         default: return nil
         }
     }

--- a/On-Dot/On-Dot/Network/Router.swift
+++ b/On-Dot/On-Dot/Network/Router.swift
@@ -46,7 +46,8 @@ enum Router: URLRequestConvertible {
         case .searchPlace: "/places/search"
             
         // MARK: Schedule
-        case .createSchedule, .getSchedules, .deleteSchedule: "/schedules"
+        case .createSchedule, .getSchedules: "/schedules"
+        case .deleteSchedule(let scheduleId): "/schedules/\(scheduleId)"
             
         // MARK: Member
         case .onboarding: "/members/onboarding"
@@ -86,10 +87,6 @@ enum Router: URLRequestConvertible {
         case .searchPlace(let query):
             return [
                 URLQueryItem(name: "query", value: query)
-            ]
-        case .deleteSchedule(let scheduleId):
-            return [
-                URLQueryItem(name: "scheduleId", value: String(scheduleId))
             ]
         default: return nil
         }

--- a/On-Dot/On-Dot/Network/Router.swift
+++ b/On-Dot/On-Dot/Network/Router.swift
@@ -20,6 +20,7 @@ enum Router: URLRequestConvertible {
     case createSchedule(schedule: ScheduleInfo)
     case getSchedules
     case deleteSchedule(scheduleId: Int)
+    case getScheduleDetail(scheduleId: Int)
     
     // MARK: Member
     case onboarding(onboardingRequest: OnboardingRequest)
@@ -31,7 +32,7 @@ enum Router: URLRequestConvertible {
     var method: HTTPMethod {
         switch self {
         case .login, .createSchedule, .calculate: .post
-        case .searchPlace, .getSchedules: .get
+        case .searchPlace, .getSchedules, .getScheduleDetail: .get
         case .onboarding: .put
         case .deleteSchedule: .delete
         }
@@ -47,7 +48,7 @@ enum Router: URLRequestConvertible {
             
         // MARK: Schedule
         case .createSchedule, .getSchedules: "/schedules"
-        case .deleteSchedule(let scheduleId): "/schedules/\(scheduleId)"
+        case .deleteSchedule(let scheduleId), .getScheduleDetail(let scheduleId): "/schedules/\(scheduleId)"
             
         // MARK: Member
         case .onboarding: "/members/onboarding"
@@ -125,7 +126,16 @@ enum Router: URLRequestConvertible {
 
 extension Encodable {
     func asDictionary() throws -> [String: Any] {
-        let data = try JSONEncoder().encode(self)
+        let encoder = JSONEncoder()
+        
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss"
+        formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+        formatter.locale = Locale(identifier: "ko_KR")
+        
+        encoder.dateEncodingStrategy = .formatted(formatter)
+        
+        let data = try encoder.encode(self)
         let dictionary = try JSONSerialization.jsonObject(with: data, options: .allowFragments)
         guard let result = dictionary as? [String: Any] else {
             throw RequestError.decode

--- a/On-Dot/On-Dot/Util/DateFormatterUtil.swift
+++ b/On-Dot/On-Dot/Util/DateFormatterUtil.swift
@@ -62,6 +62,14 @@ struct DateFormatterUtil {
         return dateFormatter.string(from: date)
     }
     
+    // 날짜를 시간과 분으로 분리해서 반환 (예: 7, 20)
+    static func extractHourAndMinute(from date: Date) -> (hour: Int, minute: Int) {
+        let components = Calendar.current.dateComponents([.hour, .minute], from: date)
+        let hour = components.hour ?? 0
+        let minute = components.minute ?? 0
+        return (hour, minute)
+    }
+    
     /// 첫 번째 Date에서 날짜를 가져오고, 두 번째 Date에서 시간을 가져와 새로운 Date 생성
     static func combineDateAndTime(date: Date, time: Date) -> Date? {
         var calendar = Calendar.current

--- a/On-Dot/On-Dot/View/Home/HomeView.swift
+++ b/On-Dot/On-Dot/View/Home/HomeView.swift
@@ -84,13 +84,29 @@ struct HomeView: View {
                         lastFocusedField: $viewModel.lastFocusedField,
                         fromLocation: $viewModel.editableSchedule.departurePlace.title,
                         toLocation: $viewModel.editableSchedule.arrivalPlace.title,
-                        selectedDate: viewModel.formattedDate,
-                        selectedTime: viewModel.formattedTime,
-                        selectedWeekdays: Set(viewModel.editableSchedule.repeatDays),
+                        isRepeatOn: $viewModel.editableSchedule.isRepeat,
+                        isChecked: $viewModel.isChecked,
+                        meridiem: $viewModel.meridiem,
+                        hour: $viewModel.hour,
+                        minute: $viewModel.minute,
+                        formattedSelectedDate: viewModel.formattedDate,
+                        formattedSelectedTime: viewModel.formattedTime,
+                        selectedWeekdays: viewModel.activeWeekdays,
                         isConfirmMode: false,
                         departureAlarm: viewModel.editableSchedule.departureAlarm,
                         preparationAlarm: viewModel.editableSchedule.preparationAlarm,
-                        onClickCreateButton: { path.removeLast() },
+                        activeCheckChip: viewModel.activeCheckChip,
+                        selectedDate: viewModel.selectedDate,
+                        selectedTime: viewModel.selectedTime,
+                        referenceDate: viewModel.referenceDate,
+                        onClickCreateButton: {
+                            Task {
+                                await viewModel.editSchedule()
+                                await MainActor.run {
+                                    path.removeLast()
+                                }
+                            }
+                        },
                         onClickBackButton: { path.removeLast() },
                         onClickDeleteButton: {
                             Task {
@@ -98,8 +114,16 @@ struct HomeView: View {
                                 viewModel.editableScheduleId = -1
                             }
                             path.removeLast()
-                        }
+                        },
+                        onClickToggle: { viewModel.onClickToggle() },
+                        onClickCheckTextChip: { index in viewModel.onClickTextCheckChip(index: index) },
+                        onClickTextChip: { newValue in viewModel.onClickTextChip(index: newValue) },
+                        increaseMonth: { viewModel.increaseMonth() },
+                        decreaseMonth: { viewModel.decreaseMonth() },
+                        onClickDate: { date in viewModel.onClickDate(date: date) },
+                        updateSelectedTime: { viewModel.updateSelectedTime() }
                     )
+                    .ignoresSafeArea(.keyboard, edges: .bottom)
                     .toolbar(.hidden, for: .tabBar)
                     .navigationBarBackButtonHidden(true)
                     .enableSwipeBack()

--- a/On-Dot/On-Dot/View/Home/HomeView.swift
+++ b/On-Dot/On-Dot/View/Home/HomeView.swift
@@ -41,10 +41,10 @@ struct HomeView: View {
                         },
                         onScheduleSelected: { id in
                             Task {
-                                viewModel.editableScheduleId = id
+                                await MainActor.run { viewModel.editableScheduleId = id }
                                 await viewModel.getScheduleDetail(id: id)
+                                await MainActor.run { path.append(HomeViewDestination.edit) }
                             }
-                            path.append(HomeViewDestination.edit)
                         }
                     )
                 }

--- a/On-Dot/On-Dot/View/Home/HomeView.swift
+++ b/On-Dot/On-Dot/View/Home/HomeView.swift
@@ -25,7 +25,7 @@ struct HomeView: View {
                     
                     Spacer().frame(height: 16)
                     
-                    RemainingTimeView(day: -1, hour: -1, minute: -1)
+                    RemainingTimeView(alarmDate: viewModel.earliestAlarmAt)
                     
                     Spacer().frame(height: 36)
                     

--- a/On-Dot/On-Dot/View/Home/HomeView.swift
+++ b/On-Dot/On-Dot/View/Home/HomeView.swift
@@ -101,7 +101,7 @@ struct HomeView: View {
 }
 
 struct ScheduleAlarmListView: View {
-    let scheduleList: [ScheduleModel]
+    let scheduleList: [HomeScheduleInfo]
     
     var onClickToggle: (Int, Bool) -> Void
     var onDelete: (Int) -> Void

--- a/On-Dot/On-Dot/View/Home/HomeView.swift
+++ b/On-Dot/On-Dot/View/Home/HomeView.swift
@@ -40,7 +40,9 @@ struct HomeView: View {
                             }
                         },
                         onScheduleSelected: { id in
-                            // TODO: 일정 상세 조회 API 호출
+                            Task {
+                                await viewModel.getScheduleDetail(id: id)
+                            }
                             path.append(HomeViewDestination.edit)
                         }
                     )

--- a/On-Dot/On-Dot/View/Home/HomeView.swift
+++ b/On-Dot/On-Dot/View/Home/HomeView.swift
@@ -98,6 +98,11 @@ struct HomeView: View {
                     .enableSwipeBack()
                 }
             }
+            .onAppear {
+                Task {
+                    await viewModel.getSchedules()
+                }
+            }
         }
     }
 }

--- a/On-Dot/On-Dot/View/Home/HomeView.swift
+++ b/On-Dot/On-Dot/View/Home/HomeView.swift
@@ -35,7 +35,9 @@ struct HomeView: View {
                             viewModel.updateScheduleAlarmEnabled(id: id, isOn: isOn)
                         },
                         onDelete: { id in
-                            viewModel.deleteSchedule(id: id)
+                            Task {
+                                await viewModel.deleteSchedule(id: id)
+                            }
                         },
                         onScheduleSelected: { id in
                             // TODO: 일정 상세 조회 API 호출

--- a/On-Dot/On-Dot/View/Home/HomeView.swift
+++ b/On-Dot/On-Dot/View/Home/HomeView.swift
@@ -41,6 +41,7 @@ struct HomeView: View {
                         },
                         onScheduleSelected: { id in
                             Task {
+                                viewModel.editableScheduleId = id
                                 await viewModel.getScheduleDetail(id: id)
                             }
                             path.append(HomeViewDestination.edit)
@@ -92,6 +93,10 @@ struct HomeView: View {
                         onClickCreateButton: { path.removeLast() },
                         onClickBackButton: { path.removeLast() },
                         onClickDeleteButton: {
+                            Task {
+                                await viewModel.deleteSchedule(id: viewModel.editableScheduleId)
+                                viewModel.editableScheduleId = -1
+                            }
                             path.removeLast()
                         }
                     )

--- a/On-Dot/On-Dot/View/Home/HomeViewModel.swift
+++ b/On-Dot/On-Dot/View/Home/HomeViewModel.swift
@@ -26,7 +26,6 @@ final class HomeViewModel: ObservableObject {
     ) {
         self.scheduleRepository = scheduleRepository
         
-//        loadSampleData()
         Task {
             await getSchedules()
         }
@@ -53,15 +52,19 @@ final class HomeViewModel: ObservableObject {
         }
     }
     
-    func deleteSchedule(id: Int) {
-        if let index = scheduleList.firstIndex(where: { $0.id == id }) {
+    func deleteSchedule(id: Int) async {
+        do {
+            guard let index = scheduleList.firstIndex(where: { $0.id == id }) else { return }
+            
             let deletedItem = scheduleList[index]
             recentlyDeleted = (item: deletedItem, index: index)
             scheduleList.remove(at: index)
             showDeleteCompletionToast = true
             
-            let summary = scheduleList.map { "(\($0.id): \($0.title))" }.joined(separator: ", ")
-            print("Schedule List: [\(summary)]")
+            try await scheduleRepository.deleteSchedule(id: id)
+            await getSchedules()
+        } catch {
+            print("일정 삭제 실패: \(error)")
         }
     }
     

--- a/On-Dot/On-Dot/View/Home/HomeViewModel.swift
+++ b/On-Dot/On-Dot/View/Home/HomeViewModel.swift
@@ -136,12 +136,14 @@ final class HomeViewModel: ObservableObject {
             
             await MainActor.run {
                 editableSchedule = response
-                activeWeekdays = Set(response.repeatDays)
+                activeWeekdays = Set(response.repeatDays.map { $0 - 1 })
                 selectedDate = response.appointmentAt
                 selectedTime = response.appointmentAt
                 meridiem = DateFormatterUtil.formatMeridiem(response.appointmentAt)
                 (hour, minute) = DateFormatterUtil.extractHourAndMinute(from: response.appointmentAt)
             }
+            
+            print("ㄴㄴㄴㄴ activeWeekdays: \(activeWeekdays)")
         } catch {
             print("일정 상세 조회 실패: \(error)")
         }

--- a/On-Dot/On-Dot/View/Home/HomeViewModel.swift
+++ b/On-Dot/On-Dot/View/Home/HomeViewModel.swift
@@ -81,11 +81,15 @@ final class HomeViewModel: ObservableObject {
     }
     
     func increaseMonth() {
-        referenceDate = Calendar.current.date(byAdding: .month, value: +1, to: referenceDate)!
+        if let newDate = Calendar.current.date(byAdding: .month, value: 1, to: referenceDate) {
+            referenceDate = newDate
+        }
     }
     
     func decreaseMonth() {
-        referenceDate = Calendar.current.date(byAdding: .month, value: -1, to: referenceDate)!
+        if let newDate = Calendar.current.date(byAdding: .month, value: -1, to: referenceDate) {
+            referenceDate = newDate
+        }
     }
     
     func onClickDate(date: Date) {

--- a/On-Dot/On-Dot/View/Home/HomeViewModel.swift
+++ b/On-Dot/On-Dot/View/Home/HomeViewModel.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 final class HomeViewModel: ObservableObject {
-    @Published var scheduleList: [ScheduleModel] = []
+    @Published var scheduleList: [HomeScheduleInfo] = []
     @Published var isShrunk: Bool = false
     @Published var showDeleteCompletionToast: Bool = false
     
@@ -16,7 +16,7 @@ final class HomeViewModel: ObservableObject {
     @Published var editableSchedule: ScheduleInfo = .placeholder
     @Published var lastFocusedField: FocusField = .from
     
-    private var recentlyDeleted: (item: ScheduleModel, index: Int)?
+    private var recentlyDeleted: (item: HomeScheduleInfo, index: Int)?
     
     init() {
         loadSampleData()
@@ -24,9 +24,9 @@ final class HomeViewModel: ObservableObject {
     
     private func loadSampleData() {
         scheduleList = [
-            ScheduleModel(id: 1, title: "일정1", isRepeat: false, repeatDays: [], appointmentAt: Date(), preparationTriggeredAt: Date(), departureTriggeredAt: Date(), isEnabled: true),
-            ScheduleModel(id: 2, title: "일정2", isRepeat: false, repeatDays: [], appointmentAt: Date(), preparationTriggeredAt: nil, departureTriggeredAt: Date(), isEnabled: false),
-            ScheduleModel(id: 3, title: "일정3", isRepeat: true, repeatDays: [1, 7], appointmentAt: Date(), preparationTriggeredAt: Date(), departureTriggeredAt: Date(), isEnabled: false)
+            HomeScheduleInfo(id: 1, title: "일정1", isRepeat: false, repeatDays: [], appointmentAt: Date(), nextAlarmAt: Date(), preparationTriggeredAt: Date(), departureTriggeredAt: Date(), isEnabled: true),
+            HomeScheduleInfo(id: 2, title: "일정2", isRepeat: false, repeatDays: [], appointmentAt: Date(), nextAlarmAt: Date(), preparationTriggeredAt: nil, departureTriggeredAt: Date(), isEnabled: false),
+            HomeScheduleInfo(id: 3, title: "일정3", isRepeat: true, repeatDays: [1, 7], appointmentAt: Date(), nextAlarmAt: Date(), preparationTriggeredAt: Date(), departureTriggeredAt: Date(), isEnabled: false)
         ]
     }
     

--- a/On-Dot/On-Dot/View/Home/HomeViewModel.swift
+++ b/On-Dot/On-Dot/View/Home/HomeViewModel.swift
@@ -18,6 +18,7 @@ final class HomeViewModel: ObservableObject {
     // MARK: - EditSchedule State
     @Published var editableSchedule: ScheduleInfo = .placeholder
     @Published var lastFocusedField: FocusField = .from
+    var editableScheduleId: Int = -1
     
     private var recentlyDeleted: (item: HomeScheduleInfo, index: Int)?
     

--- a/On-Dot/On-Dot/View/Home/HomeViewModel.swift
+++ b/On-Dot/On-Dot/View/Home/HomeViewModel.swift
@@ -61,6 +61,14 @@ final class HomeViewModel: ObservableObject {
         }
     }
     
+    func editSchedule() async {
+        do {
+            try await scheduleRepository.editSchedule(id: editableScheduleId, schedule: editableSchedule)
+        } catch {
+            print("일정 수정 실패: \(error)")
+        }
+    }
+    
     func deleteSchedule(id: Int) async {
         do {
             await MainActor.run {

--- a/On-Dot/On-Dot/View/Home/HomeViewModel.swift
+++ b/On-Dot/On-Dot/View/Home/HomeViewModel.swift
@@ -48,6 +48,18 @@ final class HomeViewModel: ObservableObject {
         }
     }
     
+    func getScheduleDetail(id: Int) async {
+        do {
+            let response = try await scheduleRepository.getScheduleDetail(id: id)
+            
+            await MainActor.run {
+                editableSchedule = response
+            }
+        } catch {
+            print("일정 상세 조회 실패: \(error)")
+        }
+    }
+    
     func deleteSchedule(id: Int) async {
         do {
             await MainActor.run {
@@ -87,10 +99,6 @@ final class HomeViewModel: ObservableObject {
 }
 
 extension HomeViewModel {
-//    var appointmentDate: Date? {
-//        return try? DateFormatterUtil.parseSimpleDate(from: editableSchedule.appointmentAt)
-//    }
-    
     var formattedDate: String {
         return DateFormatterUtil.formatDate(editableSchedule.appointmentAt, separator: "-")
     }

--- a/On-Dot/On-Dot/View/Home/HomeViewModel.swift
+++ b/On-Dot/On-Dot/View/Home/HomeViewModel.swift
@@ -157,7 +157,10 @@ final class HomeViewModel: ObservableObject {
                 }
             }
             
+            guard let time = selectedTime else { return }
+            
             let repeatDays = activeWeekdays.map { $0 + 1 }.sorted()
+            guard let combinedDate = DateFormatterUtil.combineDateAndTime(date: selectedDate ?? Date(), time: time) else { return }
             
             try await scheduleRepository.editSchedule(
                 id: editableScheduleId,
@@ -165,7 +168,7 @@ final class HomeViewModel: ObservableObject {
                     title: editableSchedule.title,
                     isRepeat: editableSchedule.isRepeat,
                     repeatDays: repeatDays,
-                    appointmentAt: selectedDate!,
+                    appointmentAt: combinedDate,
                     departurePlace: editableSchedule.departurePlace,
                     arrivalPlace: editableSchedule.arrivalPlace,
                     preparationAlarm: editableSchedule.preparationAlarm,

--- a/On-Dot/On-Dot/View/Schedule/General/FromToSearchView.swift
+++ b/On-Dot/On-Dot/View/Schedule/General/FromToSearchView.swift
@@ -79,9 +79,12 @@ struct FromToSearchView: View {
                                 .onTapGesture {
                                     if focusedField == .from {
                                         viewModel.selectedFromLocation = location
+                                        print("selectedFromLocation: \(viewModel.selectedFromLocation)")
                                     } else if focusedField == .to {
                                         viewModel.selectedToLocation = location
+                                        print("selectedToLocation: \(viewModel.selectedToLocation)")
                                     }
+                                    
                                     viewModel.onClickLocationItem(location: location)
                                 }
                             Rectangle().fill(Color.gray800).frame(maxWidth: .infinity).frame(height: 0.5)
@@ -102,9 +105,6 @@ struct FromToSearchView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onAppear {
-            focusedField = .from
-        }
         .onChange(of: viewModel.isFromLocationSelected) { _ in
             checkIfLocationSelectionCompleted()
         }

--- a/On-Dot/On-Dot/View/Schedule/General/GeneralScheduleCreateView.swift
+++ b/On-Dot/On-Dot/View/Schedule/General/GeneralScheduleCreateView.swift
@@ -106,7 +106,11 @@ struct GeneralScheduleCreateView: View {
                     .navigationBarBackButtonHidden(true)
                 case .calculate:
                     DepartureTimeCalculatingView(
-                        onCalculatingFinished: { path.append(GeneralSchedule.confirm) }
+                        onCalculatingFinished: {
+                            viewModel.onCalculatingFinished()
+                            path.removeLast()
+                            path.append(GeneralSchedule.confirm)
+                        }
                     )
                     .navigationBarBackButtonHidden(true)
                 case .confirm:

--- a/On-Dot/On-Dot/View/Schedule/General/GeneralScheduleCreateView.swift
+++ b/On-Dot/On-Dot/View/Schedule/General/GeneralScheduleCreateView.swift
@@ -107,9 +107,11 @@ struct GeneralScheduleCreateView: View {
                 case .calculate:
                     DepartureTimeCalculatingView(
                         onCalculatingFinished: {
-                            viewModel.onCalculatingFinished()
-                            path.removeLast()
-                            path.append(GeneralSchedule.confirm)
+                            Task { @MainActor in
+                                viewModel.onCalculatingFinished()
+                                path.removeLast()
+                                path.append(GeneralSchedule.confirm)
+                            }
                         }
                     )
                     .navigationBarBackButtonHidden(true)

--- a/On-Dot/On-Dot/View/Schedule/General/GeneralScheduleCreateView.swift
+++ b/On-Dot/On-Dot/View/Schedule/General/GeneralScheduleCreateView.swift
@@ -119,17 +119,28 @@ struct GeneralScheduleCreateView: View {
                         lastFocusedField: $viewModel.lastFocusedField,
                         fromLocation: $viewModel.fromLocation,
                         toLocation: $viewModel.toLocation,
-                        selectedDate: viewModel.formattedSelectedDate,
-                        selectedTime: viewModel.formattedSelectedTime,
+                        isRepeatOn: $viewModel.isRepeatOn,
+                        isChecked: $viewModel.isChecked,
+                        meridiem: $viewModel.meridiem,
+                        hour: $viewModel.hour,
+                        minute: $viewModel.minute,
+                        formattedSelectedDate: viewModel.formattedSelectedDate,
+                        formattedSelectedTime: viewModel.formattedSelectedTime,
                         selectedWeekdays: viewModel.activeWeekdays,
                         isConfirmMode: true,
                         departureAlarm: viewModel.departureAlarm,
                         preparationAlarm: viewModel.preparationAlarm,
+                        activeCheckChip: viewModel.activeCheckChip,
+                        selectedDate: viewModel.selectedDate,
+                        selectedTime: viewModel.selectedTime,
+                        referenceDate: viewModel.referenceDate,
                         onClickCreateButton: {
                             Task {
                                 await viewModel.createSchedule()
+                                await MainActor.run {
+                                    onClickBtnClose()
+                                }
                             }
-                            onClickBtnClose()
                         },
                         onClickBackButton: { path.removeLast() }
                     )

--- a/On-Dot/On-Dot/View/Schedule/General/GeneralScheduleCreateViewModel.swift
+++ b/On-Dot/On-Dot/View/Schedule/General/GeneralScheduleCreateViewModel.swift
@@ -58,7 +58,7 @@ final class GeneralScheduleCreateViewModel: ObservableObject {
     @Published var newScheduleTitle: String = "새로운 일정"
     @Published var departureAlarm: AlarmInfo = .placeholder
     @Published var preparationAlarm: AlarmInfo = .placeholder
-    private var appointmentAt: String = ""
+    private var appointmentAt: Date = Date()
     
     // MARK: - GeneralScheduleCreateView Handler
     func createSchedule() async {
@@ -189,7 +189,7 @@ final class GeneralScheduleCreateViewModel: ObservableObject {
                 return
             }
             
-            appointmentAt = DateFormatterUtil.toISO8601String(from: combinedDate)
+            appointmentAt = combinedDate
 
             let request = CalculateRequest(
                 appointmentAt: appointmentAt,

--- a/On-Dot/On-Dot/View/Schedule/General/GeneralScheduleCreateViewModel.swift
+++ b/On-Dot/On-Dot/View/Schedule/General/GeneralScheduleCreateViewModel.swift
@@ -63,11 +63,13 @@ final class GeneralScheduleCreateViewModel: ObservableObject {
     // MARK: - GeneralScheduleCreateView Handler
     func createSchedule() async {
         do {
+            let repeatDays = activeWeekdays.map { $0 + 1 }.sorted()
+            
             try await scheduleRepository.createSchedule(
                 schedule: ScheduleInfo(
                     title: newScheduleTitle,
                     isRepeat: isRepeatOn,
-                    repeatDays: Array(activeWeekdays),
+                    repeatDays: repeatDays,
                     appointmentAt: appointmentAt,
                     departurePlace: selectedFromLocation,
                     arrivalPlace: selectedToLocation,
@@ -176,9 +178,8 @@ final class GeneralScheduleCreateViewModel: ObservableObject {
     func onLocationSelected() async {
         do {
             guard
-                let date = selectedDate,
                 let time = selectedTime,
-                let combinedDate = DateFormatterUtil.combineDateAndTime(date: date, time: time)
+                let combinedDate = DateFormatterUtil.combineDateAndTime(date: selectedDate ?? Date(), time: time)
             else {
                 print("""
                 ❌ 필수 데이터 부족

--- a/On-Dot/On-Dot/View/Schedule/General/GeneralScheduleCreateViewModel.swift
+++ b/On-Dot/On-Dot/View/Schedule/General/GeneralScheduleCreateViewModel.swift
@@ -199,6 +199,8 @@ final class GeneralScheduleCreateViewModel: ObservableObject {
                 endLatitude: selectedToLocation.latitude
             )
             
+            print("요청값: \(request)")
+            
             let response = try await alarmRepository.calculateAlarm(request: request)
             
             await MainActor.run {
@@ -211,8 +213,9 @@ final class GeneralScheduleCreateViewModel: ObservableObject {
     }
     
     // MARK: - ButtonHandler
-    func onClickButton() {
-        
+    func onCalculatingFinished() {
+        fromLocation = fromLocation.isEmpty ? selectedFromLocation.roadAddress : fromLocation
+        toLocation = toLocation.isEmpty ? selectedToLocation.roadAddress : toLocation
     }
     
     func onClickLocationItem(location: LocationInfo) {

--- a/On-Dot/On-Dot/View/Utils/SwipeableItemView.swift
+++ b/On-Dot/On-Dot/View/Utils/SwipeableItemView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct SwipeableItemView: View {
-    let item: ScheduleModel
+    let item: HomeScheduleInfo
     var onClickToggle: (Bool) -> Void
     var onDelete: () -> Void
     var onItemSelected: (Int) -> Void = { _ in }


### PR DESCRIPTION
## 이슈 번호
> 작업이 완료된 이슈의 번호를 기록해주세요.

- close #53 

## 작업내용
> 작업한 내용을 설명해주세요. 왜 수정했는지? 무엇을 구현했는지? 등등

- [x] 일정 조회 서버 통신 구현
- [x] 일정 수정 서버 통신 구현
- [x] 일정 삭제 서버 통신 구현
- [x] 일정 상세 조회 서버 통신 구현



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 커스텀 메시지와 색상 지원 토스트 뷰 추가
  - 하단 시트(바텀시트) 컴포넌트 및 날짜/시간 추출 유틸리티 추가
  - 일정 목록, 상세, 삭제, 수정 등 스케줄 관리 네트워크 기능 및 데이터 모델 추가

- **기능 개선**
  - 일정 데이터 모델 및 뷰모델 전반을 `Date` 타입 기반으로 리팩터링
  - 일정 편집/생성 화면에서 반복, 날짜, 시간, 요일 등 상세 바인딩 및 상호작용 강화
  - 홈 화면에서 비동기 일정 조회 및 삭제, 상세 조회, 수정 지원

- **UI/UX 개선**
  - 일정 편집 시 인라인 제목 수정, 날짜/시간 바텀시트, 반복설정 등 편의성 향상
  - 위치 입력 필드 내 삭제 버튼 크기 축소, 레이아웃 단순화

- **버그 수정**
  - 불필요한 변수 및 주석 코드 정리, 기본값 미설정 콜백에 디폴트 추가

- **기타**
  - 내부 네트워크, 데이터 처리 로직 및 날짜 포맷 일관성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->