### PR TITLE
Feat: 로그인 화면, 자동 로그인 구현

### DIFF
--- a/On-Dot/On-Dot/App/On_DotApp.swift
+++ b/On-Dot/On-Dot/App/On_DotApp.swift
@@ -72,7 +72,7 @@ final class NotificationDelegate: NSObject, UNUserNotificationCenterDelegate {
 //            object: nil,
 //            userInfo: response.notification.request.content.userInfo
 //        )
-        return []
+        return [.banner, .sound]
     }
 
     // 알림 탭했을 때 (잠금 해제 포함)

--- a/On-Dot/On-Dot/DesignSystem/Color.swift
+++ b/On-Dot/On-Dot/DesignSystem/Color.swift
@@ -126,4 +126,12 @@ extension Color {
         startPoint: .top,
         endPoint: .bottom
     )
+    static let gradientLogin = LinearGradient(
+        gradient: Gradient(colors: [
+            Color(hex: 0xFF1B1B1B),
+            Color(hex: 0xFF2A340D)
+        ]),
+        startPoint: .top,
+        endPoint: .bottom
+    )
 }

--- a/On-Dot/On-Dot/DesignSystem/Components/Composite/CreateSchedule/General/DateTimeSettingView.swift
+++ b/On-Dot/On-Dot/DesignSystem/Components/Composite/CreateSchedule/General/DateTimeSettingView.swift
@@ -33,9 +33,11 @@ struct DateTimeSettingView: View {
                 isActive: isActiveCalendar
             )
             .padding(.horizontal, 20)
-            .onTapGesture {
-                onClickSelectedDateView()
-            }
+            .simultaneousGesture (
+                TapGesture().onEnded {
+                    onClickSelectedDateView()
+                }
+            )
             
             Spacer().frame(height: 16)
             
@@ -70,9 +72,12 @@ struct DateTimeSettingView: View {
                 isActive: isActiveTimePicker
             )
             .padding(.horizontal, 20)
-            .onTapGesture {
-                onClickSelectedTimeView()
-            }
+            .simultaneousGesture (
+                TapGesture().onEnded {
+                    onClickSelectedTimeView()
+                }   
+            )
+                
             
             if isActiveTimePicker {
                 Spacer().frame(height: 16)

--- a/On-Dot/On-Dot/DesignSystem/Components/Composite/SelectedDateTimeView.swift
+++ b/On-Dot/On-Dot/DesignSystem/Components/Composite/SelectedDateTimeView.swift
@@ -26,7 +26,7 @@ struct SelectedDateTimeView: View {
                     ForEach(0..<7, id: \.self) { index in
                         Text(AppConstants.weekdaySymbolsKR[index])
                             .font(OnDotTypo.bodyMediumR)
-                            .foregroundColor(selectedWeekdays.contains(index) ? .gray50 : .gray400)
+                            .foregroundColor(selectedWeekdays.contains(index) ? .gray50 : isConfirmMode ? .green800 : .gray400)
                             .frame(width: 20, height: 24)
                     }
                 }

--- a/On-Dot/On-Dot/DesignSystem/Components/Composite/StepProgressBar.swift
+++ b/On-Dot/On-Dot/DesignSystem/Components/Composite/StepProgressBar.swift
@@ -13,7 +13,7 @@ struct StepProgressBar: View {
     
     var body: some View {
         GeometryReader { geometry in
-            let barWidth = (geometry.size.width - CGFloat(totalStep - 1) * 4) / CGFloat(totalStep)
+            let barWidth = max(0, (geometry.size.width - CGFloat(totalStep - 1) * 4) / CGFloat(totalStep))
             
             HStack(spacing: 4) {
                 ForEach(0..<totalStep, id: \.self) { index in

--- a/On-Dot/On-Dot/Model/Schedule/HomeScheduleResponse.swift
+++ b/On-Dot/On-Dot/Model/Schedule/HomeScheduleResponse.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct HomeScheduleResponse: Codable {
     let isOnboardingCompleted: Bool
-    let earliestAlarmAt: Date
+    let earliestAlarmAt: Date?
     let hasNext: Bool
     let scheduleList: [HomeScheduleInfo]
 }

--- a/On-Dot/On-Dot/Network/NetworkManager.swift
+++ b/On-Dot/On-Dot/Network/NetworkManager.swift
@@ -72,11 +72,8 @@ final class NetworkManager {
     
     @discardableResult
     func refreshToken() async -> Bool {
-        guard let accessToken = keychainManager.readToken(for: "accessToken") else { return false }
-        guard let refreshToken = keychainManager.readToken(for: "refreshToken") else { return false }
-        
         do {
-            let response = try await AuthRepositoryImpl().refreshToken(request: JwtTokenModel(accessToken: accessToken, refreshToken: refreshToken))
+            let response = try await AuthRepositoryImpl().refreshToken()
             
             KeychainManager.shared.saveToken(response.accessToken, for: "accessToken")
             KeychainManager.shared.saveToken(response.refreshToken, for: "refreshToken")

--- a/On-Dot/On-Dot/Network/Repository/AuthRepository.swift
+++ b/On-Dot/On-Dot/Network/Repository/AuthRepository.swift
@@ -8,5 +8,5 @@
 protocol AuthRepository {
     func login(provider: String, accessToken: String) async throws -> LoginResponse
     func logout() async throws -> Void
-    func refreshToken(request: JwtTokenModel) async throws -> JwtTokenModel
+    func refreshToken() async throws -> JwtTokenModel
 }

--- a/On-Dot/On-Dot/Network/Repository/AuthRepository.swift
+++ b/On-Dot/On-Dot/Network/Repository/AuthRepository.swift
@@ -8,4 +8,5 @@
 protocol AuthRepository {
     func login(provider: String, accessToken: String) async throws -> LoginResponse
     func logout() async throws -> Void
+    func refreshToken(request: JwtTokenModel) async throws -> JwtTokenModel
 }

--- a/On-Dot/On-Dot/Network/RepositoryImpl/AuthRepositoryImpl.swift
+++ b/On-Dot/On-Dot/Network/RepositoryImpl/AuthRepositoryImpl.swift
@@ -20,7 +20,7 @@ final class AuthRepositoryImpl: AuthRepository {
         _ = try await networkManager.request(type: EmptyResponse.self, api: .logout)
     }
     
-    func refreshToken(request: JwtTokenModel) async throws -> JwtTokenModel {
-        try await networkManager.request(type: JwtTokenModel.self, api: .refresh(token: request))
+    func refreshToken() async throws -> JwtTokenModel {
+        try await networkManager.request(type: JwtTokenModel.self, api: .refresh)
     }
 }

--- a/On-Dot/On-Dot/Network/RepositoryImpl/AuthRepositoryImpl.swift
+++ b/On-Dot/On-Dot/Network/RepositoryImpl/AuthRepositoryImpl.swift
@@ -19,4 +19,8 @@ final class AuthRepositoryImpl: AuthRepository {
     func logout() async throws {
         _ = try await networkManager.request(type: EmptyResponse.self, api: .logout)
     }
+    
+    func refreshToken(request: JwtTokenModel) async throws -> JwtTokenModel {
+        try await networkManager.request(type: JwtTokenModel.self, api: .refresh(token: request))
+    }
 }

--- a/On-Dot/On-Dot/Network/Router.swift
+++ b/On-Dot/On-Dot/Network/Router.swift
@@ -13,6 +13,7 @@ enum Router: URLRequestConvertible {
     // MARK: Auth
     case login(provider: String, accessToken: String)
     case logout
+    case refresh(token: JwtTokenModel)
 
     // MARK: Location
     case searchPlace(query: String)
@@ -37,7 +38,7 @@ enum Router: URLRequestConvertible {
     // MARK: -
     var method: HTTPMethod {
         switch self {
-        case .login, .createSchedule, .calculate, .withdrawal, .logout: .post
+        case .login, .createSchedule, .calculate, .withdrawal, .logout, .refresh: .post
         case .searchPlace, .getSchedules, .getScheduleDetail, .getHomeAddress: .get
         case .onboarding, .editSchedule: .put
         case .editHomeAddress, .editMapProvider: .patch
@@ -50,6 +51,7 @@ enum Router: URLRequestConvertible {
         // MARK: Auth
         case .login: "/auth/login/oauth"
         case .logout: "/auth/logout"
+        case .refresh: "/auth/refresh"
         
         // MARK: Location
         case .searchPlace: "/places/search"
@@ -94,6 +96,8 @@ enum Router: URLRequestConvertible {
             return try? request.asDictionary()
         case .editMapProvider(let request):
             return try? request.asDictionary()
+        case .refresh(let token):
+            return try? token.asDictionary()
         default: return nil
         }
     }

--- a/On-Dot/On-Dot/Network/Router.swift
+++ b/On-Dot/On-Dot/Network/Router.swift
@@ -13,7 +13,7 @@ enum Router: URLRequestConvertible {
     // MARK: Auth
     case login(provider: String, accessToken: String)
     case logout
-    case refresh(token: JwtTokenModel)
+    case refresh
 
     // MARK: Location
     case searchPlace(query: String)
@@ -51,7 +51,7 @@ enum Router: URLRequestConvertible {
         // MARK: Auth
         case .login: "/auth/login/oauth"
         case .logout: "/auth/logout"
-        case .refresh: "/auth/refresh"
+        case .refresh: "/auth/reissue"
         
         // MARK: Location
         case .searchPlace: "/places/search"
@@ -74,9 +74,17 @@ enum Router: URLRequestConvertible {
 
     var headers: HTTPHeaders {
         var headers: HTTPHeaders = ["Content-Type": "application/json"]
-        if let token = KeychainManager.shared.readToken(for: "accessToken") {
-            headers.add(name: "Authorization", value: "Bearer \(token)")
+        switch self {
+        case .refresh:
+            if let token = KeychainManager.shared.readToken(for: "refreshToken") {
+                headers.add(name: "Authorization", value: "Bearer \(token)")
+            }
+        default:
+            if let token = KeychainManager.shared.readToken(for: "accessToken") {
+                headers.add(name: "Authorization", value: "Bearer \(token)")
+            }
         }
+        
         return headers
     }
 
@@ -96,8 +104,6 @@ enum Router: URLRequestConvertible {
             return try? request.asDictionary()
         case .editMapProvider(let request):
             return try? request.asDictionary()
-        case .refresh(let token):
-            return try? token.asDictionary()
         default: return nil
         }
     }

--- a/On-Dot/On-Dot/On-Dot.entitlements
+++ b/On-Dot/On-Dot/On-Dot.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/On-Dot/On-Dot/Util/Alarm/AlarmService.swift
+++ b/On-Dot/On-Dot/Util/Alarm/AlarmService.swift
@@ -78,6 +78,9 @@ final class AlarmService {
                 repeats: false
             )
         )
+        
+        print("[알림 등록] \(id)-\(type) → \(date)")
+        
         UNUserNotificationCenter.current().add(request)
     }
 

--- a/On-Dot/On-Dot/View/ContentView.swift
+++ b/On-Dot/On-Dot/View/ContentView.swift
@@ -17,8 +17,12 @@ struct ContentView: View {
             
             switch router.state {
             case .splash:
-                SplashView(onSplashCompleted: {
-                    router.state = .auth
+                SplashView(onSplashCompleted: { skipLogin in
+                    if skipLogin {
+                        router.state = .main
+                    } else {
+                        router.state = .auth
+                    }
                 })
             case .auth:
                 LoginView(

--- a/On-Dot/On-Dot/View/Home/HomeViewModel.swift
+++ b/On-Dot/On-Dot/View/Home/HomeViewModel.swift
@@ -123,7 +123,10 @@ final class HomeViewModel: ObservableObject {
             
             await MainActor.run {
                 scheduleList = response.scheduleList
-                earliestAlarmAt = response.earliestAlarmAt
+                
+                if let alarm = response.earliestAlarmAt { earliestAlarmAt = alarm }
+                else if !response.scheduleList.isEmpty { earliestAlarmAt = response.scheduleList[0].nextAlarmAt }
+                
                 AlarmService.shared.scheduleAlarms(for: scheduleList)
             }
         } catch {

--- a/On-Dot/On-Dot/View/Login/LoginView.swift
+++ b/On-Dot/On-Dot/View/Login/LoginView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 import KakaoSDKCommon
 import KakaoSDKAuth
 import KakaoSDKUser
+import AuthenticationServices
 
 struct LoginView: View {
     @StateObject private var viewModel = LoginViewModel()
@@ -19,11 +20,22 @@ struct LoginView: View {
         ZStack {
             Color.gray900.ignoresSafeArea()
             
-            VStack {
+            Color.gradientLogin
+                .ignoresSafeArea()
+                .padding(.top, 100)
+            
+            VStack(spacing: 0) {
+                
+                Image("ic_login")
+                    .padding(.top, 189)
+                
                 Spacer()
                 
-                OnDotButton(
-                    content: "카카오 로그인",
+                loginButton(
+                    title: "카카오로 계속하기",
+                    image: "ic_kakao",
+                    foregroundColor: .gray900,
+                    backgroundColor: Color(hex: 0xFFFAE100),
                     action: {
                         if UserApi.isKakaoTalkLoginAvailable() {
                             loginWithKaKaoApp()
@@ -31,10 +43,19 @@ struct LoginView: View {
                             // 앱 미설치 시 계정 로그인
                             loginWithKakaoAccount()
                         }
-                    },
-                    style: .green500
+                    }
                 )
-                .padding(.bottom, 20)
+                
+                Spacer().frame(height: 16)
+                
+                loginButton(
+                    title: "Apple로 계속하기",
+                    image: "ic_apple",
+                    foregroundColor: .gray0,
+                    backgroundColor: .gray900,
+                    action: loginWithApple
+                )
+                .padding(.bottom, 22)
             }
             .padding(.horizontal, 22)
         }
@@ -72,6 +93,44 @@ struct LoginView: View {
                     }
                 }
             }
+        }
+    }
+    
+    // ASAuthorizationController를 띄우는 메서드
+    private func loginWithApple() {
+        // 애플 로그인 요청 객체, 여기에 원하는 정보를 설정할 수 있음
+        let request = ASAuthorizationAppleIDProvider().createRequest()
+        request.requestedScopes = [.fullName, .email]
+
+        // 애플 로그인 과정을 처리할 컨트롤러 생성, 로그인 성공/실패를 받기 위한 델리게이트로 뷰모델 설정
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        controller.delegate = viewModel        // LoginViewModel이 ASAuthorizationControllerDelegate 채택
+        controller.presentationContextProvider = viewModel
+        controller.performRequests()
+    }
+    
+    @ViewBuilder
+    private func loginButton(
+        title: String,
+        image: String,
+        foregroundColor: Color,
+        backgroundColor: Color,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(alignment: .center, spacing: 10) {
+                Image(image)
+                
+                Text(title)
+                    .font(OnDotTypo.titleSmallSB)
+                    .foregroundStyle(foregroundColor)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 18)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(backgroundColor)
+            )
         }
     }
 }

--- a/On-Dot/On-Dot/View/Login/LoginViewModel.swift
+++ b/On-Dot/On-Dot/View/Login/LoginViewModel.swift
@@ -68,16 +68,25 @@ extension LoginViewModel: ASAuthorizationControllerDelegate, ASAuthorizationCont
         didCompleteWithAuthorization authorization: ASAuthorization
     ) {
         guard let appleID = authorization.credential as? ASAuthorizationAppleIDCredential,
-              let data = appleID.identityToken,
-              let tokenString = String(data: data, encoding: .utf8)
+              let data = appleID.identityToken
         else {
             print("AppleIDCredential or token parsing failed")
             return
         }
         
+        guard let authorizationCode = appleID.authorizationCode else { return }
+        guard let authorizationCodeString = String(data: authorizationCode, encoding: .utf8) else { return }
+        
+        let fullName = appleID.fullName
+        let email = appleID.email
+        
+        print("Apple 로그인 성공")
+        print("email: \(email ?? "nil")")
+        print("fullName: \(fullName?.formatted() ?? "nil")")
+        
         // 받은 토큰으로 서버 로그인
         Task {
-            await appleLogin(token: tokenString)
+            await appleLogin(token: authorizationCodeString)
         }
     }
     

--- a/On-Dot/On-Dot/View/Login/LoginViewModel.swift
+++ b/On-Dot/On-Dot/View/Login/LoginViewModel.swift
@@ -6,8 +6,9 @@
 //
 
 import SwiftUI
+import AuthenticationServices
 
-final class LoginViewModel: ObservableObject {
+final class LoginViewModel: NSObject, ObservableObject {
     private let authRepository: AuthRepository
     private let keyChainManager: KeychainManager
     
@@ -22,6 +23,7 @@ final class LoginViewModel: ObservableObject {
         self.keyChainManager = keyChainManager
     }
     
+    // MARK: - 카카오 로그인
     func kakaoLogin(token: String) async {
         do {
             let response = try await authRepository.login(provider: "KAKAO", accessToken: token)
@@ -37,5 +39,60 @@ final class LoginViewModel: ObservableObject {
                 print("Login Error: \(error)")
             }
         }
+    }
+    
+    // MARK: - 애플 로그인 API 호출
+    func appleLogin(token: String) async {
+        do {
+            let response = try await authRepository.login(provider: "APPLE", accessToken: token)
+            await MainActor.run {
+                keyChainManager.saveToken(response.accessToken, for: "accessToken")
+                keyChainManager.saveToken(response.refreshToken, for: "refreshToken")
+                isNewUser = !response.isOnboardingCompleted
+                isLoginSuccessful = true
+            }
+        } catch {
+            await MainActor.run {
+                print("Apple Login Error:", error)
+            }
+        }
+    }
+}
+
+// MARK: – ASAuthorizationControllerDelegate & PresentationContextProviding
+extension LoginViewModel: ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
+    
+    // 1) 인증 성공 시 호출
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        guard let appleID = authorization.credential as? ASAuthorizationAppleIDCredential,
+              let data = appleID.identityToken,
+              let tokenString = String(data: data, encoding: .utf8)
+        else {
+            print("AppleIDCredential or token parsing failed")
+            return
+        }
+        
+        // 받은 토큰으로 서버 로그인
+        Task {
+            await appleLogin(token: tokenString)
+        }
+    }
+    
+    // 2) 인증 실패 시 호출
+    func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithError error: Error
+    ) {
+        print("애플 로그인 인증 실패:", error)
+    }
+    
+    // 3) ASAuthorizationController 가 표시될 윈도우 앵커
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return UIApplication.shared.connectedScenes
+            .compactMap { ($0 as? UIWindowScene)?.keyWindow }
+            .first ?? ASPresentationAnchor()
     }
 }

--- a/On-Dot/On-Dot/View/My/Account/AccountWithdrawalView.swift
+++ b/On-Dot/On-Dot/View/My/Account/AccountWithdrawalView.swift
@@ -11,6 +11,7 @@ struct AccountWithdrawalView: View {
     @EnvironmentObject private var viewModel: MyPageViewModel
     
     var onClickBackButton: () -> Void
+    var navigateToLoginView: () -> Void
     
     var body: some View {
         ZStack {
@@ -100,7 +101,10 @@ struct AccountWithdrawalView: View {
                     onClickBtnPositive: {
                         Task {
                             await viewModel.deleteAccount()
-                            await MainActor.run { viewModel.showWithdrawalCompletedDialog = false }
+                            await MainActor.run {
+                                navigateToLoginView()
+                                viewModel.showWithdrawalCompletedDialog = false
+                            }
                         }
                     },
                     onClickBtnNegative: { viewModel.showWithdrawalCompletedDialog = false },

--- a/On-Dot/On-Dot/View/My/General/HomeAddressEditView.swift
+++ b/On-Dot/On-Dot/View/My/General/HomeAddressEditView.swift
@@ -21,7 +21,8 @@ struct HomeAddressEditView: View {
             
             VStack(alignment: .leading, spacing: 0) {
                 TopBar(
-                    image: "ic_back"
+                    image: "ic_back",
+                    onClickButton: onClickBackButton
                 )
                 .padding(.horizontal, 16)
                 
@@ -104,12 +105,6 @@ struct HomeAddressEditView: View {
                 .onTapGesture {
                     focusState = false
                 }
-                .gesture(
-                    DragGesture()
-                        .onChanged { _ in
-                            focusState = false
-                        }
-                )
             }
             .frame(maxWidth: .infinity)
         }

--- a/On-Dot/On-Dot/View/My/MyPageView.swift
+++ b/On-Dot/On-Dot/View/My/MyPageView.swift
@@ -116,7 +116,8 @@ struct MyPageView: View {
                     .enableSwipeBack()
                 case .withdrawal:
                     AccountWithdrawalView(
-                        onClickBackButton: { path.removeLast() }
+                        onClickBackButton: { path.removeLast() },
+                        navigateToLoginView: navigateToLoginView
                     )
                     .toolbar(.hidden, for: .tabBar)
                     .environmentObject(viewModel)

--- a/On-Dot/On-Dot/View/Onboarding/OnboardingView.swift
+++ b/On-Dot/On-Dot/View/Onboarding/OnboardingView.swift
@@ -136,7 +136,24 @@ struct OnboardingView: View {
                 }
             }
             .fullScreenCover(isPresented: $showAddressWebView) {
-                AddressWebView(isPresented: $showAddressWebView, address: $viewModel.address)
+                ZStack {
+                    AddressWebView(isPresented: $showAddressWebView, address: $viewModel.address)
+                    
+                    VStack {
+                        Spacer()
+                        
+                        Button(action: {
+                            showAddressWebView = false
+                        }) {
+                            Image(systemName: "xmark.circle.fill")
+                                .resizable()
+                                .frame(width: 30, height: 30)
+                                .padding(.bottom, 100)
+                                .foregroundColor(.gray)
+                        }
+                    }
+                }
+                .ignoresSafeArea(.keyboard, edges: .bottom)
             }
             .navigationDestination(for: Onboarding.self) { view in
                 switch view {

--- a/On-Dot/On-Dot/View/Schedule/General/FromToSearchView.swift
+++ b/On-Dot/On-Dot/View/Schedule/General/FromToSearchView.swift
@@ -77,10 +77,10 @@ struct FromToSearchView: View {
                         ForEach(viewModel.searchResult) { location in
                             LocationSearchItemView(keyword: viewModel.currentKeyword, title: location.title, detail: location.roadAddress)
                                 .onTapGesture {
-                                    if focusedField == .from {
+                                    if viewModel.lastFocusedField == .from {
                                         viewModel.selectedFromLocation = location
                                         print("selectedFromLocation: \(viewModel.selectedFromLocation)")
-                                    } else if focusedField == .to {
+                                    } else if viewModel.lastFocusedField == .to {
                                         viewModel.selectedToLocation = location
                                         print("selectedToLocation: \(viewModel.selectedToLocation)")
                                     }

--- a/On-Dot/On-Dot/View/Schedule/General/GeneralScheduleCreateView.swift
+++ b/On-Dot/On-Dot/View/Schedule/General/GeneralScheduleCreateView.swift
@@ -95,7 +95,6 @@ struct GeneralScheduleCreateView: View {
                         selectedTime: viewModel.formattedSelectedTime,
                         onClickBack: { path.removeLast() },
                         isLocationSelected: {
-                            path.removeLast()
                             path.append(GeneralSchedule.calculate)
                             Task {
                                 await viewModel.onLocationSelected()

--- a/On-Dot/On-Dot/View/Splash/SplashView.swift
+++ b/On-Dot/On-Dot/View/Splash/SplashView.swift
@@ -8,13 +8,15 @@
 import SwiftUI
 
 struct SplashView: View {
-    var onSplashCompleted: () -> Void
+    @ObservedObject private var viewModel = SplashViewModel()
+    
+    var onSplashCompleted: (Bool) -> Void
     
     var body: some View {
         ZStack(alignment: .center) {
             Color.gray900.ignoresSafeArea()
             
-            LottieView(name: "Splash", loopMode: .playOnce, onCompleted: onSplashCompleted)
+            LottieView(name: "Splash", loopMode: .playOnce, onCompleted: { onSplashCompleted(viewModel.skipLogin) })
                 .frame(width: 206, height: 40)
         }
     }

--- a/On-Dot/On-Dot/View/Splash/SplashViewModel.swift
+++ b/On-Dot/On-Dot/View/Splash/SplashViewModel.swift
@@ -1,0 +1,42 @@
+//
+//  SplashViewModel.swift
+//  On-Dot
+//
+//  Created by 현수 노트북 on 5/5/25.
+//
+
+import SwiftUI
+
+final class SplashViewModel: ObservableObject {
+    private let authRepository: AuthRepository
+    private let keychainManager: KeychainManager
+    
+    @Published var skipLogin: Bool = false
+    
+    init(
+        authRepository: AuthRepository = AuthRepositoryImpl(),
+        keychainManager: KeychainManager = KeychainManager.shared
+    ) {
+        self.authRepository = authRepository
+        self.keychainManager = keychainManager
+        
+        Task {
+            await refreshToken()
+        }
+    }
+    
+    func refreshToken() async {
+        do {
+            let response = try await authRepository.refreshToken()
+            
+            keychainManager.saveToken(response.accessToken, for: "accessToken")
+            keychainManager.saveToken(response.refreshToken, for: "refreshToken")
+            
+            await MainActor.run {
+                skipLogin = true
+            }
+        } catch {
+            print("토큰 갱신 실패: \(error)")
+        }
+    }
+}


### PR DESCRIPTION
## 이슈 번호
> 작업이 완료된 이슈의 번호를 기록해주세요.

- close #59 

## 작업내용
> 작업한 내용을 설명해주세요. 왜 수정했는지? 무엇을 구현했는지? 등등

- [x] 로그인 화면 구현
- [x] SplashView 자동 로그인 구현
- [x] 토큰 갱신 서버 통신 구현
- [x] 토큰 갱신 로직 구현


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
  - Apple 로그인 기능이 추가되어, 카카오와 함께 로그인 옵션이 제공됩니다.
  - 스플래시 화면에서 자동 로그인(토큰 갱신)에 성공하면 로그인 화면을 건너뜁니다.
  - 계정 탈퇴 후 로그인 화면으로 자동 이동합니다.
  - 주소 검색 화면에 닫기 버튼이 추가되었습니다.
  - 로그인 배경이 그라데이션으로 변경되었습니다.

- **개선 및 변경**
  - 푸시 알림이 앱 실행 중에도 배너와 소리로 표시됩니다.
  - 네트워크 요청 시 인증 만료(401) 발생 시 토큰 자동 갱신 및 재시도 기능이 추가되었습니다.
  - 로그아웃/탈퇴 시 저장된 토큰이 안전하게 삭제됩니다.
  - 일정 생성·편집 및 날짜/시간 선택 UI의 제스처 인식과 색상 표시가 개선되었습니다.
  - 계정 관리 및 내 정보 화면에서 뒤로가기 동작이 명확해졌습니다.

- **버그 수정**
  - 단계 진행 바의 레이아웃 오류(너비 음수) 방지 로직이 추가되었습니다.
  - 일정 알림 시간이 없는 경우 대체값을 자동으로 설정합니다.

- **기타**
  - Apple 로그인 권한이 앱에 추가되었습니다.
  - 알림 등록 시 로그가 출력됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->